### PR TITLE
use id(“”) syntax to apply Gradle plugin

### DIFF
--- a/json-schema-processor/build.gradle
+++ b/json-schema-processor/build.gradle
@@ -1,12 +1,11 @@
 plugins {
-    id 'io.micronaut.build.internal.json-schema-module'
+    id("io.micronaut.build.internal.json-schema-module")
 }
 
 dependencies {
     compileOnly(mn.micronaut.core.processor)
 
     implementation(mn.micronaut.http)
-
     api(projects.micronautJsonSchemaAnnotations)
     api(mn.jackson.databind)
 

--- a/test-suite-groovy/build.gradle
+++ b/test-suite-groovy/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'groovy'
-    id 'io.micronaut.build.internal.json-schema-module'
+    id("io.micronaut.build.internal.json-schema-module")
 }
 
 dependencies {

--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.micronaut.build.internal.json-schema-module'
+    id("io.micronaut.build.internal.json-schema-module")
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.ksp)
 }

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.micronaut.build.internal.json-schema-module'
+    id("io.micronaut.build.internal.json-schema-module")
 }
 
 dependencies {


### PR DESCRIPTION
This syntax is compatible both with the Gradle and Kotlin DSL.