### PR TITLE
Generate build plugin sources for JSON schema generator

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.json-schema-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.json-schema-base.gradle
@@ -5,3 +5,10 @@ tasks.withType(Test).configureEach {
         exceptionFormat = 'full'
     }
 }
+
+repositories {
+    mavenCentral()
+    maven {
+        url("https://s01.oss.sonatype.org/content/repositories/snapshots")
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ micronaut-logging = "1.6.1"
 micronaut-serde = "2.14.0"
 micronaut-test = "4.7.0"
 micronaut-sourcegen = "1.7.5"
+micronaut-build-plugin-sourcegen = "0.0.1-SNAPSHOT"
 micronaut-validation = "4.9.0"
 micronaut-serialization = "2.12.0"
 groovy = "4.0.24"
@@ -39,6 +40,7 @@ micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.r
 micronaut-test = { module = "io.micronaut.test:micronaut-test-bom", version.ref = "micronaut-test" }
 micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-bom", version.ref = "micronaut-validation" }
 micronaut-sourcegen = { module = "io.micronaut.sourcegen:micronaut-sourcegen-bom", version.ref = "micronaut-sourcegen" }
+micronaut-build-plugin-sourcegen = { module = "io.micronaut.build.plugin.sourcegen:micronaut-build-plugin-sourcegen-bom", version.ref = "micronaut-build-plugin-sourcegen" }
 micronaut-serialization = { module = "io.micronaut.serialization:micronaut-serialization-bom", version.ref = "micronaut-serialization" }
 
 managed-json-schema-validator = { module = "com.networknt:json-schema-validator", version.ref = "managed-json-schema-validator" }

--- a/json-schema-generator/build.gradle
+++ b/json-schema-generator/build.gradle
@@ -11,6 +11,9 @@ dependencies {
     implementation(mnSourcegen.micronaut.sourcegen.annotations)
     implementation(mnSerde.micronaut.serde.jackson)
 
+    compileOnly(mnBuildPluginSourcegen.micronaut.build.plugin.sourcegen.annotations)
+    annotationProcessor(mnBuildPluginSourcegen.micronaut.build.plugin.sourcegen.generator)
+
     api(projects.micronautJsonSchemaAnnotations)
     api(projects.micronautJsonSchemaCommon)
 

--- a/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/SourceGenerator.java
+++ b/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/SourceGenerator.java
@@ -112,14 +112,14 @@ public final class SourceGenerator {
     /**
      * Generates source code from JSON schema files based on the provided configuration.
      * <p>
-     * This method first checks if an {@code inputFolder} is specified in the configuration. If the
-     * {@code inputFolder} is provided, it processes all JSON Schema in the folder to generate source code.
-     * If {@code inputFolder} is {@code null}, it attempts to retrieve the JSON schema from the specified
-     * {@code inputStream}, {@code jsonUrl}, or {@code jsonFile} in the configuration and generates code from the schema.
+     * This method first checks if an {@code inputDirectory} is specified in the configuration. If the
+     * {@code inputDirectory} is provided, it processes all JSON Schema in the folder to generate source code.
+     * If {@code inputDirectory} is {@code null}, it attempts to retrieve the JSON schema from the specified
+     * {@code inputStream}, {@code inputURL}, or {@code inputFile} in the configuration and generates code from the schema.
      * </p>
      * <p>
      * If the {@code outputFileName} exists, the method generates a single source file from the schema with that file name.
-     * Otherwise, the method generates all objects defined in the schema inside the specified {@code outputPath}
+     * Otherwise, the method generates all objects defined in the schema inside the specified {@code outputDirectory}
      * (and {@code outputPackageName} if available).
      * </p>
      *

--- a/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/loaders/FileProcessor.java
+++ b/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/loaders/FileProcessor.java
@@ -27,6 +27,9 @@ import java.util.Optional;
 
 import static io.micronaut.jsonschema.generator.aggregator.TypeAggregator.getClassName;
 
+/**
+ * A utility class for loading JSON schemas from the file system.
+ */
 @Internal
 public class FileProcessor {
 
@@ -49,7 +52,7 @@ public class FileProcessor {
             } else if (config.jsonFile() != null) {
                 loader = new FileLoader(config.jsonFile());
             } else {
-                throw new RuntimeException("Missing required config.jsonUrl(), config.inputStream(), or config.jsonFile().");
+                throw new RuntimeException("Missing required config.inputURL(), config.inputStream(), or config.inputFile().");
             }
             return loader.load();
         } catch (RuntimeException e) {

--- a/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/plugin/JsonSchemaGeneratorTask.java
+++ b/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/plugin/JsonSchemaGeneratorTask.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jsonschema.generator.plugin;
+
+import io.micronaut.inject.visitor.VisitorContext;
+import io.micronaut.jsonschema.generator.SourceGenerator;
+import io.micronaut.jsonschema.generator.loaders.UrlLoader;
+import io.micronaut.jsonschema.generator.utils.GeneratorContext;
+import io.micronaut.jsonschema.generator.utils.SourceGeneratorConfig;
+import io.micronaut.sourcegen.annotations.PluginTask;
+import io.micronaut.sourcegen.annotations.PluginTaskExecutable;
+import io.micronaut.sourcegen.annotations.PluginTaskParameter;
+import io.micronaut.sourcegen.annotations.PluginTaskParameter.OutputType;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * A configuration class for the JSON schema source generator, encapsulating the configuration
+ * properties related to the input and output paths, file names, and URL.
+ *
+ * @param inputURL The URL of the JSON schema file to be downloaded and processed
+ * @param inputFile The JSON schema file, typically ending in {@code .schema.json}
+ * @param inputDirectory The path to the folder where the input files (JSON schemas) are located.
+ *                    Each of the files in the directory will be used for generation
+ * @param language The programming language to generate the output types in.
+ * @param outputPackageName The package name to be applied to the generated source files
+ *                    This field is optional and can be {@code null} if no package name is needed
+ * @param outputFileName The name of the file where the generated source code will be written
+ *                       if there is a single output source.
+ * @param acceptedUrlPatterns The URL patterns that are allowed.
+ *                           Used to filter or validate input resources specified by URL.
+ *                           URLs matching at least one pattern will be accepted. The default
+ *                           value is {@code "^https://.* /.*.json"}
+ * @param outputDirectory The path where generated source files will be saved
+ *                   The path should be a valid, writable directory path
+ * @param javaOutputDirectory Internal output path for Java sources
+ * @param groovyOutputDirectory Internal output path for Groovy sources
+ * @param kotlinOutputDirectory Internal output path for Kotlin sources
+ * @author Andriy Dmytruk
+ * @version 1.5
+ */
+@PluginTask
+public record JsonSchemaGeneratorTask(
+    String inputURL,
+    File inputFile,
+    @PluginTaskParameter(directory = true)
+    File inputDirectory,
+    @PluginTaskParameter(defaultValue = "io.micronaut.jsonschema")
+    String outputPackageName,
+    String outputFileName,
+    @PluginTaskParameter(defaultValue = "JAVA")
+    Language language,
+    @PluginTaskParameter
+    List<String> acceptedUrlPatterns,
+    @PluginTaskParameter(directory = true, output = OutputType.CUSTOM, required = true)
+    File outputDirectory,
+    @PluginTaskParameter(directory = true, output = OutputType.JAVA_SOURCES, internal = true)
+    File javaOutputDirectory,
+    @PluginTaskParameter(directory = true, output = OutputType.GROOVY_SOURCES, internal = true)
+    File groovyOutputDirectory,
+    @PluginTaskParameter(directory = true, output = OutputType.KOTLIN_SOURCES, internal = true)
+    File kotlinOutputDirectory
+) {
+
+    @PluginTaskExecutable
+    public void generate() {
+        if (inputDirectory == null && inputURL == null && inputFile == null) {
+            throw new IllegalArgumentException("Must provide oneOf: inputDirectory, inputURL, inputFile");
+        }
+        if (acceptedUrlPatterns != null) {
+            UrlLoader.setAllowedUrlPatterns(acceptedUrlPatterns);
+        }
+
+        File languageDir = switch (language) {
+            case JAVA -> javaOutputDirectory;
+            case GROOVY -> groovyOutputDirectory;
+            case KOTLIN -> kotlinOutputDirectory;
+        };
+        SourceGenerator generator = new SourceGenerator(VisitorContext.Language.valueOf(language.name()), new GeneratorContext());
+        try {
+            generator.generate(new SourceGeneratorConfig(
+                null,
+                inputURL,
+                    inputFile,
+                inputDirectory == null ? null : inputDirectory.toPath(),
+                languageDir.toPath(),
+                outputPackageName,
+                outputFileName
+            ));
+        } catch (IOException e) {
+            throw new RuntimeException("Could not generate based on JSON schema", e);
+        }
+    }
+
+    /**
+     * A language to generated sources in.
+     */
+    public enum Language {
+        /** The Java language. */
+        JAVA,
+        /** The Groovy language. */
+        GROOVY,
+        /** The Kotlin language. */
+        KOTLIN
+    }
+}

--- a/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/plugin/JsonSchemaGeneratorTask.java
+++ b/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/plugin/JsonSchemaGeneratorTask.java
@@ -20,6 +20,9 @@ import io.micronaut.jsonschema.generator.SourceGenerator;
 import io.micronaut.jsonschema.generator.loaders.UrlLoader;
 import io.micronaut.jsonschema.generator.utils.GeneratorContext;
 import io.micronaut.jsonschema.generator.utils.SourceGeneratorConfig;
+import io.micronaut.jsonschema.generator.utils.SourceGeneratorConfig.JavadocConfig;
+import io.micronaut.jsonschema.generator.utils.SourceGeneratorConfig.RecordAdoptionStrategy;
+import io.micronaut.jsonschema.generator.utils.SourceGeneratorConfigBuilder;
 import io.micronaut.sourcegen.annotations.PluginTask;
 import io.micronaut.sourcegen.annotations.PluginTaskExecutable;
 import io.micronaut.sourcegen.annotations.PluginTaskParameter;
@@ -67,6 +70,8 @@ public record JsonSchemaGeneratorTask(
     Language language,
     @PluginTaskParameter
     List<String> acceptedUrlPatterns,
+    JavadocConfig javadoc,
+    RecordAdoptionStrategy recordAdoptionStrategy,
     @PluginTaskParameter(directory = true, output = OutputType.CUSTOM, required = true)
     File outputDirectory,
     @PluginTaskParameter(directory = true, output = OutputType.JAVA_SOURCES, internal = true)
@@ -91,17 +96,19 @@ public record JsonSchemaGeneratorTask(
             case GROOVY -> groovyOutputDirectory;
             case KOTLIN -> kotlinOutputDirectory;
         };
-        SourceGenerator generator = new SourceGenerator(VisitorContext.Language.valueOf(language.name()), new GeneratorContext());
+        SourceGenerator generator = new SourceGenerator(language.name());
         try {
-            generator.generate(new SourceGeneratorConfig(
-                null,
-                inputURL,
-                    inputFile,
-                inputDirectory == null ? null : inputDirectory.toPath(),
-                languageDir.toPath(),
-                outputPackageName,
-                outputFileName
-            ));
+            SourceGeneratorConfig config = new SourceGeneratorConfigBuilder()
+                .withJsonUrl(inputURL)
+                .withJsonFile(inputFile)
+                .withInputFolder(inputDirectory == null ? null : inputDirectory.toPath())
+                .withOutputFolder(languageDir.toPath())
+                .withOutputPackageName(outputPackageName)
+                .withOutputFileName(outputFileName)
+                .withJavadoc(javadoc)
+                .withRecordAdoptionStrategy(recordAdoptionStrategy)
+                .build();
+            generator.generate(config);
         } catch (IOException e) {
             throw new RuntimeException("Could not generate based on JSON schema", e);
         }

--- a/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/utils/SourceGeneratorConfig.java
+++ b/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/utils/SourceGeneratorConfig.java
@@ -25,10 +25,10 @@ import java.nio.file.Path;
  *
  * This class is used to specify:
  * <ol>
- *   <li>The URL of the JSON schema file to be processed ({@code jsonUrl})</li>
+ *   <li>The URL of the JSON schema file to be processed ({@code inputURL})</li>
  *   <li>The name of the JSON schema file ({@code jsonFileName})</li>
- *   <li>The input folder where schema files might be located ({@code inputFolder})</li>
- *   <li>The output directory for generated source files ({@code outputPath})</li>
+ *   <li>The input folder where schema files might be located ({@code inputDirectory})</li>
+ *   <li>The output directory for generated source files ({@code outputDirectory})</li>
  *   <li>The package name to be applied to the generated source files ({@code outputPackageName})</li>
  *   <li>The output file name for the generated source ({@code outputFileName})</li>
  * </ol>

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,9 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         mavenCentral()
+        maven {
+            url("https://s01.oss.sonatype.org/content/repositories/snapshots")
+        }
     }
 }
 
@@ -13,6 +16,9 @@ dependencyResolutionManagement {
     repositories {
         gradlePluginPortal()
         mavenCentral()
+        maven {
+            url("https://s01.oss.sonatype.org/content/repositories/snapshots")
+        }
     }
 }
 
@@ -39,4 +45,5 @@ micronautBuild {
     importMicronautCatalog('micronaut-validation')
     importMicronautCatalog('micronaut-serde')
     importMicronautCatalog('micronaut-sourcegen')
+    importMicronautCatalog('micronaut-build-plugin-sourcegen')
 }


### PR DESCRIPTION
Switch JSON schema to generate Maven and Gradle configurations based on [micronaut-build-plugin-sourcegen](https://micronaut-projects.github.io/micronaut-build-plugin-sourcegen/snapshot/guide/).

The generated plugins will:
- Have the same properties defined
- Have the javadoc copied as defined in this repo
- Add the generated files as build sources

This would simplify support, as additional properties would require no manual changes in the plugins. Some properties would already be added in this PR: https://github.com/micronaut-projects/micronaut-json-schema/pull/163.

## Current support

| Maven | Gradle | Plugingen |
| --- | --- | --- |
| inputURL | <strike>inputUrl</strike> | inputURL |
| inputFile | inputFile | inputFile |
| inputDirectory | inputDirectory | inputDirectory |
| language default=JAVA | <strike>lang</strike> default=JAVA | language default=JAVA |
| outputDirectory default="${project.build.directory}/generated-sources/jsonschema" | outputDirectory | outputDirectory |
| outputPackageName default=io.micronaut.jsonschema | outputPackageName | outputPackageName default=io.micronaut.jsonschema |
| outputFileName | outputFileName | outputFileName |
| acceptedUrlPatterns | acceptedUrlPatterns | acceptedUrlPatterns |
| enabled default=false | enabed default=true | enabled default=false/true |