### PR TITLE
Render type as a single string

### DIFF
--- a/json-schema-common/build.gradle
+++ b/json-schema-common/build.gradle
@@ -12,8 +12,3 @@ dependencies {
     testImplementation(mnLogging.slf4j.api)
     testImplementation(mnLogging.slf4j.simple)
 }
-
-
-test {
-    useJUnitPlatform()
-}

--- a/json-schema-common/src/main/java/io/micronaut/jsonschema/model/Schema.java
+++ b/json-schema-common/src/main/java/io/micronaut/jsonschema/model/Schema.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.micronaut.core.annotation.Internal;
 
 import java.util.ArrayList;
@@ -66,7 +67,9 @@ public final class Schema {
     /**
      * The supported types of the schema.
      */
+    @JsonSerialize(using = TypeListSerializer.class)
     private List<Type> type;
+
     private String format;
     @JsonProperty("const")
     private Object constValue;

--- a/json-schema-common/src/main/java/io/micronaut/jsonschema/model/TypeListSerializer.java
+++ b/json-schema-common/src/main/java/io/micronaut/jsonschema/model/TypeListSerializer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jsonschema.model;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.CollectionUtils;
+
+import java.io.IOException;
+import java.util.List;
+
+@Internal
+public class TypeListSerializer extends JsonSerializer<List<Schema.Type>> {
+
+    @Override
+    public void serialize(List<Schema.Type> value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        if (CollectionUtils.isEmpty(value)) {
+            gen.writeNull();
+        } else if (value.size() == 1) {
+            gen.writeString(value.get(0).value());
+        } else {
+            gen.writeStartArray();
+            for (Schema.Type t : value) {
+                gen.writeString(t.value());
+            }
+            gen.writeEndArray();
+        }
+    }
+}
+

--- a/json-schema-common/src/main/java/io/micronaut/jsonschema/model/TypeListSerializer.java
+++ b/json-schema-common/src/main/java/io/micronaut/jsonschema/model/TypeListSerializer.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import java.util.List;
 
 @Internal
-public class TypeListSerializer extends JsonSerializer<List<Schema.Type>> {
+class TypeListSerializer extends JsonSerializer<List<Schema.Type>> {
 
     @Override
     public void serialize(List<Schema.Type> value, JsonGenerator gen, SerializerProvider serializers) throws IOException {

--- a/json-schema-common/src/test/groovy/io/micronaut/jsonschema/serialization/SchemaSerializationSpec.groovy
+++ b/json-schema-common/src/test/groovy/io/micronaut/jsonschema/serialization/SchemaSerializationSpec.groovy
@@ -79,8 +79,8 @@ class SchemaSerializationSpec extends Specification {
 
         where:
         schema                                             | expectedJson
-        Schema.number().setMinimum(12).setMaximum(13)      | '{"type":["number"],"maximum":13,"minimum":12}'
-        Schema.object().putProperty("a", Schema.integer()) | '{"type":["object"],"properties":{"a":{"type":["integer"]}}}'
+        Schema.number().setMinimum(12).setMaximum(13)      | '{"type":"number","maximum":13,"minimum":12}'
+        Schema.object().putProperty("a", Schema.integer()) | '{"type":"object","properties":{"a":{"type":"integer"}}}'
     }
 
     void "test #expectedJson serialization"() {

--- a/json-schema-common/src/test/groovy/model/TypeListSerializerSpec.groovy
+++ b/json-schema-common/src/test/groovy/model/TypeListSerializerSpec.groovy
@@ -1,0 +1,41 @@
+package model
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.micronaut.jsonschema.model.Schema
+import spock.lang.Specification
+
+class TypeListSerializerSpec extends Specification {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    void serializeNoTypeToNull() {
+        when:
+        Schema schema = new Schema()
+        String json = objectMapper.writeValueAsString(schema)
+
+        then:
+        noExceptionThrown()
+        json.contains("\"type\":null")
+    }
+
+    void serializeSingleType() {
+        when:
+        Schema schema = new Schema()
+        schema.setType(List.of(Schema.Type.OBJECT))
+        String json = objectMapper.writeValueAsString(schema)
+
+        then:
+        noExceptionThrown()
+        json.contains("\"type\":\"object\"")
+    }
+
+    void serializeMultipleItemType() {
+        when:
+        Schema schema = new Schema()
+        schema.setType(List.of(Schema.Type.STRING,Schema.Type.NUMBER))
+        String json = objectMapper.writeValueAsString(schema)
+
+        then:
+        noExceptionThrown()
+        json.contains("\"type\":[\"string\",\"number\"]")
+    }
+}

--- a/json-schema-validation/src/test/resources/expected-llama.schema.json
+++ b/json-schema-validation/src/test/resources/expected-llama.schema.json
@@ -3,16 +3,16 @@
   "$id":"http://localhost:8080/schemas/llama.schema.json",
   "title":"Llama",
   "description":"A llama. <4>",
-  "type":["object"],
+  "type":"object",
   "properties":{
     "age":{
       "description":"The age",
-      "type":["integer"],
+      "type":"integer",
       "minimum":0
     },
     "name":{
       "description":"The name",
-      "type":["string"],
+      "type":"string",
       "minLength":1
     }
   },

--- a/json-schema-validation/src/test/resources/expected-rwblackbird.json
+++ b/json-schema-validation/src/test/resources/expected-rwblackbird.json
@@ -3,15 +3,15 @@
   "$id":"http://localhost:8080/schemas/red-winged-blackbird.schema.json",
   "title":"RedWingedBlackbird",
   "description":"A species of blackbird with red wings",
-  "type":["object"],
+  "type":"object",
   "properties":{
     "name":{
       "description":"The name",
-      "type":["string"]
+      "type":"string"
     },
     "wingSpan":{
       "description":"The wing span of the bird",
-      "type":["number"]
+      "type":"number"
     }
   }
 }

--- a/test-suite-groovy/src/test/groovy/io/micronaut/jsonschema/test/ObjectsValidationSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/jsonschema/test/ObjectsValidationSpec.groovy
@@ -30,7 +30,7 @@ class ObjectsValidationSpec extends Specification {
         where:
         llama | message
         '{"name":"","age":12}'            | "/name: must be at least 1 characters long"
-        '{"name":null}'                   | "/name: null found, [string] expected"
+        '{"name":null}'                   | "/name: null found, string expected"
         new Llama(name: "John", age: -12) | "/age: must have a minimum value of 0"
     }
 
@@ -50,7 +50,7 @@ class ObjectsValidationSpec extends Specification {
 
         then:
         assertions.size() == 1
-        assertions[0].message == "/name: integer found, [string] expected"
+        assertions[0].message == "/name: integer found, string expected"
     }
 
 }

--- a/test-suite-kotlin/src/test/groovy/io/micronaut/jsonschema/test/ObjectsValidationSpec.groovy
+++ b/test-suite-kotlin/src/test/groovy/io/micronaut/jsonschema/test/ObjectsValidationSpec.groovy
@@ -30,7 +30,7 @@ class ObjectsValidationSpec extends Specification {
         where:
         llama | message
         new Llama("", 12)      | "/name: must be at least 1 characters long"
-        '{"name":null}'        | "/name: null found, [string] expected"
+        '{"name":null}'        | "/name: null found, string expected"
         new Llama("John", -12) | "/age: must have a minimum value of 0"
     }
 
@@ -50,7 +50,7 @@ class ObjectsValidationSpec extends Specification {
 
         then:
         assertions.size() == 1
-        assertions[0].message == "/name: integer found, [string] expected"
+        assertions[0].message == "/name: integer found, string expected"
     }
 
 }

--- a/test-suite/src/test/groovy/io/micronaut/jsonschema/test/ObjectsValidationSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/jsonschema/test/ObjectsValidationSpec.groovy
@@ -32,7 +32,7 @@ class ObjectsValidationSpec extends Specification {
         where:
         llama | message
         new Llama("", 12)      | "/name: must be at least 1 characters long"
-        '{"name":null}'        | "/name: null found, [string] expected"
+        '{"name":null}'        | "/name: null found, string expected"
         new Llama("John", -12) | "/age: must have a minimum value of 0"
     }
 
@@ -150,7 +150,7 @@ class ObjectsValidationSpec extends Specification {
 
         then:
         assertions.size() == 1
-        assertions[0].message == "/name: integer found, [string] expected"
+        assertions[0].message == "/name: integer found, string expected"
     }
 
 }

--- a/test-suite/src/test/resources/expected-llama.schema.json
+++ b/test-suite/src/test/resources/expected-llama.schema.json
@@ -3,16 +3,16 @@
   "$id":"https://example.com/schemas/llama.schema.json",
   "title":"Llama",
   "description":"A llama. <4>",
-  "type":["object"],
+  "type":"object",
   "properties":{
     "age":{
       "description":"The age",
-      "type":["integer"],
+      "type":"integer",
       "minimum":0
     },
     "name":{
       "description":"The name",
-      "type":["string"],
+      "type":"string",
       "minLength":1
     }
   }


### PR DESCRIPTION
[Type Keyword](https://json-schema.org/understanding-json-schema/reference/type): 

> The type keyword can take two forms:
> - A single string. When it is a single string, it must be one of the types mentioned above (array, boolean, integer, number, null, object, regular expressions, or string). This specifies that the instance data is only valid when it matches that specific type.
> - An array of strings. When type is used as an array, it contains more than one string specifying the types mentioned above. In this case, the instance data is valid if it matches any of the given types.

This pull-request serializes type as a single string instead of an array. That it is to say, instead of `[“object]”` it uses `”object”`.

I am working on the [Micronaut MCP Server](https://github.com/micronaut-projects/micronaut-mcp) implementation. To implement tools, you have to provide a [JSON Schema of the Tool](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#listing-tools). Under the hood, we use the MCP Java SDK which [requires type to be a single string](https://github.com/modelcontextprotocol/java-sdk/blob/main/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java#L1218).