### PR TITLE
feat: add methods to JsonSchemaValidator

### DIFF
--- a/json-schema-validation/src/main/java/io/micronaut/jsonschema/validation/DefaultJsonSchemaValidator.java
+++ b/json-schema-validation/src/main/java/io/micronaut/jsonschema/validation/DefaultJsonSchemaValidator.java
@@ -31,8 +31,6 @@ import io.micronaut.json.JsonMapper;
 import io.micronaut.jsonschema.utils.JsonSchemaClassPathResourceLoader;
 import io.micronaut.jsonschema.utils.JsonSchemaConfiguration;
 import jakarta.inject.Singleton;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
@@ -44,7 +42,6 @@ import java.util.stream.Collectors;
 @Singleton
 @Internal
 final class DefaultJsonSchemaValidator implements JsonSchemaValidator {
-    private static final Logger LOG = LoggerFactory.getLogger(DefaultJsonSchemaValidator.class);
     private static final String CLASSPATH_PREFIX = "classpath:";
 
     private static final ExecutionContextCustomizer CONTEXT_CUSTOMIZER = (executionContext, validationContext) -> {
@@ -80,34 +77,67 @@ final class DefaultJsonSchemaValidator implements JsonSchemaValidator {
 
     @Override
     public <T> Set<? extends ValidationMessage> validate(@NonNull String json, @NonNull Class<T> type) {
-        JsonSchema schema = jsonSchemaCache.computeIfAbsent(type, this::jsonSchemaForClass);
+        JsonSchema schema = jsonSchemaCache.computeIfAbsent(type, this::jsonSchema);
         return validate(schema, json);
     }
 
     @Override
     @NonNull
-    public <T> Set<? extends ValidationMessage> validate(@NonNull Object value, @NonNull Class<T> type) throws IOException {
-        JsonSchema schema = jsonSchemaCache.computeIfAbsent(type, this::jsonSchemaForClass);
-        String json = jsonMapper.writeValueAsString(value);
-        return validate(schema, json);
+    public Set<? extends ValidationMessage> validate(@NonNull Object value, @NonNull Map<String, Object> jsonSchema) throws IOException {
+        JsonSchema schema = jsonSchema(jsonSchema);
+        return validate(schema, value);
     }
 
-    private <T> JsonSchema jsonSchemaForClass(@NonNull Class<T> type) {
+    @Override
+    @NonNull
+    public Set<? extends ValidationMessage> validate(@NonNull Object value, @NonNull String jsonSchema) throws IOException {
+        JsonSchema schema = jsonSchema(jsonSchema);
+        return validate(schema, value);
+    }
+
+    @Override
+    @NonNull
+    public <T> Set<? extends ValidationMessage> validate(@NonNull Object value, @NonNull Class<T> type) throws IOException {
+        JsonSchema schema = jsonSchemaCache.computeIfAbsent(type, this::jsonSchema);
+        return validate(schema, value);
+    }
+
+    private <T> JsonSchema jsonSchema(@NonNull Class<T> type) {
         String jsonSchema = jsonSchemaClassPathResourceLoader.jsonSchemaStringForClass(type).orElse(null);
         if (jsonSchema == null) {
             throw new IllegalArgumentException("No schema found for type: " + type);
         }
+        return jsonSchema(jsonSchema);
+    }
+
+    @NonNull
+    private JsonSchema jsonSchema(@NonNull Map<String, Object> jsonSchema) {
+        try {
+            String jsonSchemaString = jsonMapper.writeValueAsString(jsonSchema);
+            return jsonSchema(jsonSchemaString);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("could not serialize JSON Schema from: " + jsonSchema);
+        }
+    }
+
+    @NonNull
+    private JsonSchema jsonSchema(@NonNull String jsonSchema) {
         JsonSchemaFactory jsonSchemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012, builder -> {
             builder.schemaLoaders(b -> b.add(new ResourceSchemaLoader()));
         });
         return jsonSchemaFactory.getSchema(jsonSchema, schemaValidatorsConfig);
     }
 
+    private Set<? extends ValidationMessage> validate(JsonSchema schema, Object value) throws IOException {
+        String json = value instanceof String s ? s : jsonMapper.writeValueAsString(value);
+        return validate(schema, json);
+    }
+
     private static Set<? extends ValidationMessage> validate(JsonSchema schema, String json) {
         return schema.validate(json, InputFormat.JSON, CONTEXT_CUSTOMIZER)
-                .stream()
-                .map(ValidationMessageAdapter::new)
-                .collect(Collectors.toSet());
+            .stream()
+            .map(ValidationMessageAdapter::new)
+            .collect(Collectors.toSet());
     }
 
     private class ResourceSchemaLoader implements SchemaLoader {

--- a/json-schema-validation/src/main/java/io/micronaut/jsonschema/validation/JsonSchemaValidator.java
+++ b/json-schema-validation/src/main/java/io/micronaut/jsonschema/validation/JsonSchemaValidator.java
@@ -19,6 +19,7 @@ import io.micronaut.context.annotation.DefaultImplementation;
 import io.micronaut.core.annotation.NonNull;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -55,4 +56,23 @@ public interface JsonSchemaValidator {
     @NonNull
     <T> Set<? extends ValidationMessage> validate(@NonNull Object value, @NonNull Class<T> type) throws IOException;
 
+    /**
+     * Validate Object against a JSON schema.
+     *
+     * @param value Object to validate against a JSON schema
+     * @param jsonSchema The JSON Schema expressed as a Map
+     * @return A set of validation messages. Empty if valid.
+     * @throws IOException If an error occurs validating the JSON against the schema.
+     */
+    Set<? extends ValidationMessage> validate(@NonNull Object value, @NonNull Map<String, Object> jsonSchema) throws IOException;
+
+    /**
+     * Validate Object against a JSON schema.
+     *
+     * @param value Object to validate against a JSON schema
+     * @param jsonSchema The JSON Schema expressed as a Map
+     * @return A set of validation messages. Empty if valid.
+     * @throws IOException If an error occurs validating the JSON against the schema.
+     */
+    Set<? extends ValidationMessage> validate(@NonNull Object value, @NonNull String jsonSchema) throws IOException;
 }

--- a/json-schema-validation/src/test/java/io/micronaut/jsonschema/validation/BirdTest.java
+++ b/json-schema-validation/src/test/java/io/micronaut/jsonschema/validation/BirdTest.java
@@ -46,8 +46,8 @@ class BirdTest {
 
     private static Stream<Arguments> provideValid() {
         return Stream.of(
-                Arguments.of(new Ostrich("Bob", 10.5f)),
-                Arguments.of(new Eagle("Blob", 31.2f))
+            Arguments.of(new Ostrich("Bob", 10.5f)),
+            Arguments.of(new Eagle("Blob", 31.2f))
         );
     }
 

--- a/json-schema-validation/src/test/java/io/micronaut/jsonschema/validation/JsonSchemaValidatorTest.java
+++ b/json-schema-validation/src/test/java/io/micronaut/jsonschema/validation/JsonSchemaValidatorTest.java
@@ -1,0 +1,58 @@
+package io.micronaut.jsonschema.validation;
+
+import io.micronaut.core.type.Argument;
+import io.micronaut.json.JsonMapper;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
+
+@MicronautTest(startApplication = false)
+class JsonSchemaValidatorTest {
+
+    @Inject
+    JsonSchemaValidator validator;
+
+    // New: Inject ObjectMapper to parse schemaAsString into a Map
+    @Inject
+    JsonMapper objectMapper;
+
+    private final String schemaAsString = """
+        {"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"http://localhost:8080/schemas/bird.schema.json","title":"Bird","description":"A bird.","type":"object","oneOf":[{"title":"Ostrich","description":"An ostrich.","type":"object","properties":{"@type":{"type":"string","const":"ostrich-bird"},"name":{"description":"The name","type":"string"},"runSpeed":{"description":"The run speed","type":"number","exclusiveMinimum":0}},"required":["@type"]},{"title":"Eagle","description":"The eagle.","type":"object","properties":{"@type":{"type":"string","const":"eagle-bird"},"flySpeed":{"description":"The fly speed","type":"number","minimum":1},"name":{"description":"The name","type":"string"}},"required":["@type"]}]}
+        """;
+    private Map<String, Object> schemaAsMap;
+
+    @BeforeEach
+    void setUpSchemaAsMap() throws IOException {
+        schemaAsMap = objectMapper.readValue(schemaAsString, Argument.mapOf(String.class, Object.class));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideValidBirds")
+    void validateWithSchemaAsString(Bird bird) throws IOException {
+        var assertions = validator.validate(bird, schemaAsString);
+        assertEquals(0, assertions.size());
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideValidBirds")
+    void validateWithSchemaAsMap(Bird bird) throws IOException {
+        var assertions = validator.validate(bird, schemaAsMap);
+        assertEquals(0, assertions.size());
+    }
+
+    private static Stream<Arguments> provideValidBirds() {
+        return Stream.of(
+            Arguments.of(new Ostrich("Bob", 10.5f)),
+            Arguments.of(new Eagle("Blob", 31.2f))
+        );
+    }
+
+}


### PR DESCRIPTION
Add methods where the JSON Schema is supplied as a String or as a Map. I need these methods to use Micronaut JSON Schema validator to implement this API https://github.com/modelcontextprotocol/java-sdk/blob/main/mcp-json/src/main/java/io/modelcontextprotocol/json/schema/JsonSchemaValidator.java