### PR TITLE
Remove io.micronaut.build.internal.json-schema-module from test-suite

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '7.6.4'
+    id 'io.micronaut.build.shared.settings' version '7.6.6'
 }
 
 dependencyResolutionManagement {

--- a/test-suite-generator-java/build.gradle
+++ b/test-suite-generator-java/build.gradle
@@ -1,7 +1,7 @@
 import io.micronaut.build.internal.generator.BeanGeneratorTask
 
 plugins {
-    id("io.micronaut.build.internal.json-schema-module")
+    id("java-library")
     id("io.micronaut.build.internal.test-suite-generator-java")
 }
 

--- a/test-suite-generator-java/src/test/java/io/micronaut/jsonschema/generator/FoodTest.java
+++ b/test-suite-generator-java/src/test/java/io/micronaut/jsonschema/generator/FoodTest.java
@@ -21,8 +21,8 @@ import io.micronaut.jsonschema.generator.food.Food;
 import io.micronaut.jsonschema.generator.food.Fruit;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class FoodTest {
 

--- a/test-suite-generator-java/src/test/java/io/micronaut/jsonschema/generator/GenerationTest.java
+++ b/test-suite-generator-java/src/test/java/io/micronaut/jsonschema/generator/GenerationTest.java
@@ -11,9 +11,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class GenerationTest {
     @Test

--- a/test-suite-generator-java/src/test/java/io/micronaut/jsonschema/generator/animals/AnimalTest.java
+++ b/test-suite-generator-java/src/test/java/io/micronaut/jsonschema/generator/animals/AnimalTest.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AnimalTest {
 

--- a/test-suite-generator-java/src/test/java/io/micronaut/jsonschema/serialization/SerializationTest.java
+++ b/test-suite-generator-java/src/test/java/io/micronaut/jsonschema/serialization/SerializationTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @MicronautTest
 public class SerializationTest {

--- a/test-suite-groovy/build.gradle
+++ b/test-suite-groovy/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'groovy'
-    id("io.micronaut.build.internal.json-schema-module")
+    id 'java-library'
 }
 
 dependencies {

--- a/test-suite-groovy/build.gradle
+++ b/test-suite-groovy/build.gradle
@@ -23,8 +23,16 @@ dependencies {
     testImplementation(mn.micronaut.inject.groovy.test)
     testImplementation(mn.micronaut.inject.java.test)
     testImplementation(mn.micronaut.inject)
+    testImplementation(mnTest.micronaut.test.spock)
 }
 
 tasks.withType(GroovyCompile).configureEach {
     options.compilerArgs.add("-Amicronaut.jsonschema.baseUri=https://example.com/schemas")
+}
+
+tasks.withType(Test).configureEach {
+    useJUnitPlatform()
+    testLogging {
+        exceptionFormat = 'full'
+    }
 }

--- a/test-suite-groovy/build.gradle
+++ b/test-suite-groovy/build.gradle
@@ -32,7 +32,4 @@ tasks.withType(GroovyCompile).configureEach {
 
 tasks.withType(Test).configureEach {
     useJUnitPlatform()
-    testLogging {
-        exceptionFormat = 'full'
-    }
 }

--- a/test-suite-groovy/src/test/groovy/io/micronaut/jsonschema/test/ServingSchemasSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/jsonschema/test/ServingSchemasSpec.groovy
@@ -6,7 +6,6 @@ import io.micronaut.http.client.HttpClient
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
-import org.junit.Test
 import spock.lang.Specification
 
 
@@ -19,7 +18,6 @@ class ServingSchemasSpec extends Specification {
     @Inject
     HttpClient client
 
-    @Test
     void "test get schemas"() {
         when:
         String result = client.toBlocking().retrieve(

--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id("io.micronaut.build.internal.json-schema-module")
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.ksp)
 }
@@ -28,7 +27,7 @@ ksp {
     arg("micronaut.jsonschema.baseUri", "https://example.com/schemas")
 }
 
-compileTestGroovy {
-    dependsOn tasks.getByPath('compileTestKotlin')
-    classpath += files(compileTestKotlin)
-}
+//compileTestGroovy {
+//    dependsOn tasks.getByPath('compileTestKotlin')
+//    classpath += files(compileTestKotlin)
+//}

--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -33,3 +33,6 @@ compileTestGroovy {
     dependsOn tasks.getByPath('compileTestKotlin')
     classpath += files(compileTestKotlin)
 }
+test {
+    useJUnitPlatform()
+}

--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "groovy"
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.ksp)
 }
@@ -27,7 +28,7 @@ ksp {
     arg("micronaut.jsonschema.baseUri", "https://example.com/schemas")
 }
 
-//compileTestGroovy {
-//    dependsOn tasks.getByPath('compileTestKotlin')
-//    classpath += files(compileTestKotlin)
-//}
+compileTestGroovy {
+    dependsOn tasks.getByPath('compileTestKotlin')
+    classpath += files(compileTestKotlin)
+}

--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     testImplementation(mn.micronaut.inject.groovy.test)
     testImplementation(mn.micronaut.inject.java.test)
     testImplementation(mn.micronaut.inject)
+    testImplementation(mnTest.micronaut.test.spock)
 }
 
 ksp {

--- a/test-suite-kotlin/src/test/groovy/io/micronaut/jsonschema/test/ServingSchemasSpec.groovy
+++ b/test-suite-kotlin/src/test/groovy/io/micronaut/jsonschema/test/ServingSchemasSpec.groovy
@@ -1,12 +1,10 @@
 package io.micronaut.jsonschema.test
 
 import io.micronaut.http.HttpRequest
-import io.micronaut.http.MediaType
 import io.micronaut.http.client.HttpClient
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
-import org.junit.Test
 import spock.lang.Specification
 
 
@@ -19,7 +17,6 @@ class ServingSchemasSpec extends Specification {
     @Inject
     HttpClient client
 
-    @Test
     void "test get schemas"() {
         when:
         String result = client.toBlocking().retrieve(

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -31,3 +31,6 @@ dependencies {
 tasks.withType(JavaCompile).configureEach {
     options.compilerArgs.add("-Amicronaut.jsonschema.baseUri=https://example.com/schemas")
 }
+test {
+    useJUnitPlatform()
+}

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id("java-library")
+    id("groovy")
 }
 
 dependencies {
@@ -21,6 +22,7 @@ dependencies {
     testImplementation(mn.micronaut.inject.java.test)
     testImplementation(mn.micronaut.inject)
 
+    testImplementation(mnTest.micronaut.test.spock)
     testImplementation(mnTest.micronaut.test.junit5)
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("io.micronaut.build.internal.json-schema-module")
+    id("java-library")
 }
 
 dependencies {


### PR DESCRIPTION
This PR Removed `'io.micronaut.build.internal.json-schema-module'` plugin from **test-suite** modules as it's not intended for use in test-suites. 