### PR TITLE
feat: add metadata-based dependency injection validation and reporting

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=2.0.0-BUILD-SNAPSHOT
+projectVersion=2.0.0-SNAPSHOT
 projectGroup=io.micronaut.jsonschema
 
 title=Micronaut JSON schema

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=2.0.0-M2
+projectVersion=2.0.0-BUILD-SNAPSHOT
 projectGroup=io.micronaut.jsonschema
 
 title=Micronaut JSON schema

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationValidatorConfiguration.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationValidatorConfiguration.java
@@ -39,10 +39,17 @@ public final class ConfigurationValidatorConfiguration {
      * Configuration prefix.
      */
     public static final String PREFIX = "micronaut.jsonschema.configuration.validator";
+    /**
+     * Configuration prefix used by this health-indicator configuration.
+     */
+    public static final String ENDPOINT_PREFIX = "endpoints.health.injecterrors";
+
     public static final boolean DEFAULT_CACHE = true;
     public static final boolean DEFAULT_FAIL_ON_NOT_PRESENT = true;
+    public static final boolean DEFAULT_DEPENDENCY_INJECTION_ENABLED = false;
     private boolean cache = DEFAULT_CACHE;
     private boolean failOnNotPresent = DEFAULT_FAIL_ON_NOT_PRESENT;
+    private boolean dependencyInjectionEnabled = DEFAULT_DEPENDENCY_INJECTION_ENABLED;
     private List<String> suppressions = List.of();
 
     /**
@@ -80,6 +87,14 @@ public final class ConfigurationValidatorConfiguration {
      */
     public void setFailOnNotPresent(boolean failOnNotPresent) {
         this.failOnNotPresent = failOnNotPresent;
+    }
+
+    public boolean isDependencyInjectionEnabled() {
+        return dependencyInjectionEnabled;
+    }
+
+    public void setDependencyInjectionEnabled(boolean dependencyInjectionEnabled) {
+        this.dependencyInjectionEnabled = dependencyInjectionEnabled;
     }
 
     /**

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationValidatorConfiguration.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationValidatorConfiguration.java
@@ -30,7 +30,10 @@ import java.util.List;
  *     <li>{@code micronaut.jsonschema.configuration.validator.cache}</li>
  *     <li>{@code micronaut.jsonschema.configuration.validator.fail-on-not-present}</li>
  *     <li>{@code micronaut.jsonschema.configuration.validator.suppressions}</li>
- *     <li>{@code micronaut.jsonschema.configuration.validator.endpoint.enabled}</li>
+ *     <li>{@code micronaut.jsonschema.configuration.validator.dependency-injection.enabled}</li>
+ *     <li>{@code micronaut.jsonschema.configuration.validator.injecterrors.endpoint.enabled}</li>
+ *     <li>{@code endpoints.health.injecterrors.enabled}</li>
+ *     <li>{@code endpoints.health.configurationerrors.enabled} (see {@link io.micronaut.jsonschema.configuration.validator.HealthConfiguration})</li>
  * </ul>
  */
 @ConfigurationProperties(ConfigurationValidatorConfiguration.PREFIX)
@@ -40,16 +43,14 @@ public final class ConfigurationValidatorConfiguration {
      */
     public static final String PREFIX = "micronaut.jsonschema.configuration.validator";
     /**
-     * Configuration prefix used by this health-indicator configuration.
+     * Configuration prefix used by the inject-errors health-indicator configuration.
      */
     public static final String ENDPOINT_PREFIX = "endpoints.health.injecterrors";
 
     public static final boolean DEFAULT_CACHE = true;
     public static final boolean DEFAULT_FAIL_ON_NOT_PRESENT = true;
-    public static final boolean DEFAULT_DEPENDENCY_INJECTION_ENABLED = false;
     private boolean cache = DEFAULT_CACHE;
     private boolean failOnNotPresent = DEFAULT_FAIL_ON_NOT_PRESENT;
-    private boolean dependencyInjectionEnabled = DEFAULT_DEPENDENCY_INJECTION_ENABLED;
     private List<String> suppressions = List.of();
 
     /**
@@ -87,14 +88,6 @@ public final class ConfigurationValidatorConfiguration {
      */
     public void setFailOnNotPresent(boolean failOnNotPresent) {
         this.failOnNotPresent = failOnNotPresent;
-    }
-
-    public boolean isDependencyInjectionEnabled() {
-        return dependencyInjectionEnabled;
-    }
-
-    public void setDependencyInjectionEnabled(boolean dependencyInjectionEnabled) {
-        this.dependencyInjectionEnabled = dependencyInjectionEnabled;
     }
 
     /**

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationValidatorFactory.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationValidatorFactory.java
@@ -33,9 +33,4 @@ class ConfigurationValidatorFactory {
         validator.setSuppressionPatterns(configuration.getSuppressions());
         return validator;
     }
-
-    @Singleton
-    DependencyInjectionValidator dependencyInjectionValidator() {
-        return new DefaultDependencyInjectionValidator();
-    }
 }

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationValidatorFactory.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationValidatorFactory.java
@@ -33,4 +33,9 @@ class ConfigurationValidatorFactory {
         validator.setSuppressionPatterns(configuration.getSuppressions());
         return validator;
     }
+
+    @Singleton
+    DependencyInjectionValidator dependencyInjectionValidator() {
+        return new DefaultDependencyInjectionValidator();
+    }
 }

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionErrors.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionErrors.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.ConfigurableBeanContext;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Singleton
+@Requires(property = ConfigurationValidatorConfiguration.PREFIX + ".dependency-injection.enabled", value = "true")
+final class DefaultDependencyInjectionErrors implements DependencyInjectionErrors {
+    private final ConfigurableBeanContext beanContext;
+    private final ConfigurationValidatorConfiguration configuration;
+    private final DependencyInjectionValidator validator;
+    private final AtomicReference<Set<DependencyInjectionError>> cached = new AtomicReference<>();
+
+    DefaultDependencyInjectionErrors(
+        ConfigurableBeanContext beanContext,
+        ConfigurationValidatorConfiguration configuration,
+        DependencyInjectionValidator validator
+    ) {
+        this.beanContext = beanContext;
+        this.configuration = configuration;
+        this.validator = validator;
+    }
+
+    @Override
+    public Set<DependencyInjectionError> getCurrentErrors() {
+        if (!configuration.isCache()) {
+            return validateNow();
+        }
+        Set<DependencyInjectionError> existing = cached.get();
+        if (existing != null) {
+            return existing;
+        }
+        Set<DependencyInjectionError> computed = validateNow();
+        if (cached.compareAndSet(null, computed)) {
+            return computed;
+        }
+        return cached.get();
+    }
+
+    private Set<DependencyInjectionError> validateNow() {
+        return Set.copyOf(validator.validate(beanContext));
+    }
+}

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionValidator.java
@@ -39,7 +39,6 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.EntryPoint;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.order.OrderUtil;
-import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.TypeInformation;
 import io.micronaut.core.value.PropertyResolver;
@@ -283,7 +282,7 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
         for (Argument<?> argument : constructor.getArguments()) {
             requirements.add(new DependencyRequirement(
                 argument,
-                "constructor " + constructorDescription(definition, argument),
+                constructorInjectionPointDescription(definition, constructor, argument),
                 constructorSnippet(definition, argument),
                 definition.getBeanType()
             ));
@@ -335,11 +334,64 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
             || !isRequiredInjection(argument)
             || isInternalArgument(argument)
             || isContainerArgument(argument)
-            || isPrimitiveOrSimple(argument)
             || isConfigurationBean(current)
             || hasPropertyBinding(argument)
             || hasInternalName(argument)
             || requirement.injectionPoint().startsWith("method set");
+    }
+
+    private static String constructorInjectionPointDescription(
+        BeanDefinition<?> definition,
+        ConstructorInjectionPoint<?> constructor,
+        Argument<?> argument
+    ) {
+        Optional<Class<?>> declaringType = definition.getDeclaringType();
+        if (constructor instanceof MethodInjectionPoint<?, ?> methodInjectionPoint) {
+            Class<?> methodDeclaringType = declaringType.orElse(methodInjectionPoint.getDeclaringType());
+            return "method "
+                + methodDeclaringType.getSimpleName()
+                + "."
+                + methodInjectionPoint.getName()
+                + "("
+                + argument.getName()
+                + ")";
+        }
+        if (constructor instanceof FieldInjectionPoint<?, ?> fieldInjectionPoint) {
+            Class<?> fieldDeclaringType = declaringType.orElse(fieldInjectionPoint.getDeclaringBean().getBeanType());
+            return "field "
+                + fieldDeclaringType.getSimpleName()
+                + "."
+                + fieldInjectionPoint.getName();
+        }
+
+        if (declaringType.isPresent() && !declaringType.get().equals(definition.getBeanType())) {
+            String factoryMemberName = resolveFactoryMemberName(definition);
+            if (factoryMemberName != null) {
+                return "method "
+                    + declaringType.get().getSimpleName()
+                    + "."
+                    + factoryMemberName
+                    + "("
+                    + argument.getName()
+                    + ")";
+            }
+        }
+
+        return "constructor " + constructorDescription(definition, argument);
+    }
+
+    @Nullable
+    private static String resolveFactoryMemberName(BeanDefinition<?> definition) {
+        String beanDescription = definition.getBeanDescription(TypeInformation.TypeFormat.SHORTENED, false);
+        int factoryQualifierStart = beanDescription.lastIndexOf(' ');
+        String memberReference = factoryQualifierStart >= 0
+            ? beanDescription.substring(factoryQualifierStart + 1)
+            : beanDescription;
+        int lastDot = memberReference.lastIndexOf('.');
+        if (lastDot < 0 || lastDot == memberReference.length() - 1) {
+            return null;
+        }
+        return memberReference.substring(lastDot + 1);
     }
 
     private static String constructorDescription(BeanDefinition<?> definition, Argument<?> argument) {
@@ -374,10 +426,6 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
             || Collection.class.isAssignableFrom(type)
             || Map.class.isAssignableFrom(type)
             || Stream.class.isAssignableFrom(type);
-    }
-
-    private static boolean isPrimitiveOrSimple(Argument<?> argument) {
-        return ClassUtils.isJavaBasicType(argument.getType());
     }
 
     private static boolean isConfigurationBean(BeanDefinition<?> definition) {

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionValidator.java
@@ -124,17 +124,9 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
 
         Set<DependencyInjectionError> errors = new LinkedHashSet<>();
         Set<String> dedupe = new LinkedHashSet<>();
+        TraversalState traversalState = new TraversalState(beanContext, disabledByBeanName, errors, dedupe);
         for (BeanDefinition<Object> root : roots) {
-            traverse(
-                beanContext,
-                root,
-                root,
-                new LinkedHashSet<>(),
-                new ArrayList<>(),
-                errors,
-                dedupe,
-                disabledByBeanName
-            );
+            traverse(traversalState, root, root, new LinkedHashSet<>(), new ArrayList<>());
         }
         return errors;
     }
@@ -198,7 +190,7 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
     }
 
     private static Map<String, List<String>> disabledReasonsByBeanName(Collection<DisabledBean<?>> disabledBeans) {
-        Map<String, List<String>> map = new LinkedHashMap<>(disabledBeans.size());
+        Map<String, List<String>> map = new LinkedHashMap<>();
         for (DisabledBean<?> disabledBean : disabledBeans) {
             map.put(disabledBean.getName(), disabledBean.reasons());
         }
@@ -206,14 +198,11 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
     }
 
     private void traverse(
-        ConfigurableBeanContext beanContext,
+        TraversalState state,
         BeanDefinition<?> root,
         BeanDefinition<?> current,
         Set<String> stack,
-        List<String> path,
-        Set<DependencyInjectionError> errors,
-        Set<String> dedupe,
-        Map<String, List<String>> disabledByBeanName
+        List<String> path
     ) {
         String currentName = current.getName();
         if (!stack.add(currentName)) {
@@ -222,74 +211,83 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
         path.add(currentName);
         try {
             for (DependencyRequirement requirement : dependenciesOf(current)) {
-                Argument<?> argument = requirement.argument();
-                if (isSuppressed(argument)) {
-                    continue;
+                Optional<BeanDefinition<?>> target = resolveDependencyTarget(state, root, current, requirement, path);
+                if (target.isPresent()) {
+                    BeanDefinition<?> targetDefinition = target.get();
+                    if (stack.contains(targetDefinition.getName())) {
+                        addCircularDependencyError(
+                            root,
+                            requirement,
+                            targetDefinition,
+                            path,
+                            state.errors(),
+                            state.dedupe()
+                        );
+                    } else {
+                        traverse(state, root, targetDefinition, stack, path);
+                    }
                 }
-
-                String missingPropertyMessage = resolveMissingPropertyMessage(beanContext, current, argument);
-                if (missingPropertyMessage != null) {
-                    addError(
-                        root,
-                        argument,
-                        requirement,
-                        missingPropertyMessage,
-                        path,
-                        errors,
-                        dedupe,
-                        disabledByBeanName
-                    );
-                    continue;
-                }
-
-                if (skipInjection(requirement, argument, current)) {
-                    continue;
-                }
-
-                Optional<BeanDefinition<?>> target;
-                try {
-                    target = resolveBeanDefinition(beanContext, argument, Qualifiers.forArgument(argument));
-                } catch (Exception e) {
-                    addError(
-                        root,
-                        argument,
-                        requirement,
-                        sanitizeMessage(e),
-                        path,
-                        errors,
-                        dedupe,
-                        disabledByBeanName
-                    );
-                    continue;
-                }
-
-                if (target.isEmpty()) {
-                    String message = missingBeanMessage(beanContext, argument, requirement, disabledByBeanName);
-                    addError(root, argument, requirement, message, path, errors, dedupe, disabledByBeanName);
-                    continue;
-                }
-
-                BeanDefinition<?> targetDefinition = target.get();
-                if (isSuppressed(targetDefinition)) {
-                    continue;
-                }
-                if (stack.contains(targetDefinition.getName())) {
-                    addCircularDependencyError(
-                        root,
-                        requirement,
-                        targetDefinition,
-                        path,
-                        errors,
-                        dedupe
-                    );
-                    continue;
-                }
-                traverse(beanContext, root, targetDefinition, stack, path, errors, dedupe, disabledByBeanName);
             }
         } finally {
             path.removeLast();
             stack.remove(currentName);
         }
+    }
+
+    private Optional<BeanDefinition<?>> resolveDependencyTarget(
+        TraversalState state,
+        BeanDefinition<?> root,
+        BeanDefinition<?> current,
+        DependencyRequirement requirement,
+        List<String> path
+    ) {
+        Argument<?> argument = requirement.argument();
+        if (isSuppressed(argument)) {
+            return Optional.empty();
+        }
+        String missingPropertyMessage = resolveMissingPropertyMessage(state.beanContext(), current, argument);
+        if (missingPropertyMessage != null) {
+            addError(
+                root,
+                argument,
+                requirement,
+                missingPropertyMessage,
+                path,
+                state.errors(),
+                state.dedupe(),
+                state.disabledByBeanName()
+            );
+            return Optional.empty();
+        }
+        if (skipInjection(requirement, argument, current)) {
+            return Optional.empty();
+        }
+        Optional<BeanDefinition<?>> target;
+        try {
+            target = resolveBeanDefinition(state.beanContext(), argument, Qualifiers.forArgument(argument));
+        } catch (Exception e) {
+            addError(
+                root,
+                argument,
+                requirement,
+                sanitizeMessage(e),
+                path,
+                state.errors(),
+                state.dedupe(),
+                state.disabledByBeanName()
+            );
+            return Optional.empty();
+        }
+        if (target.isEmpty()) {
+            String message = missingBeanMessage(state.beanContext(), argument, requirement, state.disabledByBeanName());
+            addError(root, argument, requirement, message, path, state.errors(), state.dedupe(), state.disabledByBeanName());
+            return Optional.empty();
+        }
+        BeanDefinition<?> targetDefinition = target.get();
+        if (isSuppressed(targetDefinition)) {
+            return Optional.empty();
+        }
+        return target;
     }
 
     private boolean isSuppressed(BeanDefinition<?> definition) {
@@ -900,6 +898,7 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
                     matched.put(candidateName, new DisabledCandidate(candidateName, entry.getValue()));
                 }
             } catch (ClassNotFoundException | LinkageError ignored) {
+                LOG.trace("Unable to load disabled candidate type {} while matching {}", className, requiredTypeName, ignored);
             }
         }
         return matched.values().stream()
@@ -933,6 +932,14 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
     }
 
     private record EachPropertyOrigin(String prefix, Optional<String> primary) {
+    }
+
+    private record TraversalState(
+        ConfigurableBeanContext beanContext,
+        Map<String, List<String>> disabledByBeanName,
+        Set<DependencyInjectionError> errors,
+        Set<String> dedupe
+    ) {
     }
 
     private interface ClassSuppressionMatcher {

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionValidator.java
@@ -46,10 +46,15 @@ import jakarta.inject.Named;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -57,8 +62,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.HashSet;
-import java.lang.reflect.Modifier;
 import java.util.stream.Collectors;
 
 /**
@@ -70,6 +73,8 @@ import java.util.stream.Collectors;
  */
 @Singleton
 public final class DefaultDependencyInjectionValidator implements DependencyInjectionValidator {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultDependencyInjectionValidator.class);
+
     private static final String STARTUP_EVENT = "io.micronaut.runtime.event.StartupEvent";
     private static final String SERVER_STARTUP_EVENT = "io.micronaut.runtime.server.event.ServerStartupEvent";
 
@@ -116,7 +121,8 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
     private static void ensureConfigured(ConfigurableBeanContext beanContext) {
         try {
             beanContext.configure();
-        } catch (Exception ignored) {
+        } catch (RuntimeException e) {
+            LOG.debug("Bean context configure() failed during metadata DI validation; continuing with available definitions", e);
         }
     }
 
@@ -477,7 +483,7 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
                 continue;
             }
 
-            Optional<EachPropertyOrigin> origin = resolveEachPropertyOrigin(candidate, definitions, new HashSet<>());
+            Optional<EachPropertyOrigin> origin = resolveEachPropertyOrigin(candidate, definitions, new HashSet<>(), new HashMap<>());
             if (origin.isEmpty() || origin.get().prefix().isBlank()) {
                 continue;
             }
@@ -493,20 +499,26 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
         return Optional.empty();
     }
 
+    @SuppressWarnings("java:S3776")
     private static Optional<EachPropertyOrigin> resolveEachPropertyOrigin(
         BeanDefinition<Object> candidate,
         Collection<BeanDefinition<Object>> definitions,
-        Set<String> visited
+        Set<String> visited,
+        Map<Class<?>, List<BeanDefinition<Object>>> candidatesByType
     ) {
         if (!visited.add(candidate.getName())) {
             return Optional.empty();
         }
 
         for (Argument<?> constructorArgument : candidate.getConstructor().getArguments()) {
-            for (BeanDefinition<Object> definition : definitions) {
-                if (!constructorArgument.getType().isAssignableFrom(definition.getBeanType())) {
-                    continue;
-                }
+            List<BeanDefinition<Object>> candidatesForArgument = candidatesByType.computeIfAbsent(
+                constructorArgument.getType(),
+                type -> definitions.stream()
+                    .filter(definition -> type.isAssignableFrom(definition.getBeanType()))
+                    .toList()
+            );
+
+            for (BeanDefinition<Object> definition : candidatesForArgument) {
                 if (definition.getAnnotationMetadata().hasStereotype(EachProperty.class)) {
                     Optional<String> prefix = definition.getAnnotationMetadata().stringValue(EachProperty.class);
                     if (prefix.isPresent() && !prefix.get().isBlank()) {
@@ -518,14 +530,11 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
                 }
             }
 
-            for (BeanDefinition<Object> definition : definitions) {
-                if (!constructorArgument.getType().isAssignableFrom(definition.getBeanType())) {
-                    continue;
-                }
+            for (BeanDefinition<Object> definition : candidatesForArgument) {
                 if (!definition.getAnnotationMetadata().hasStereotype(EachBean.class)) {
                     continue;
                 }
-                Optional<EachPropertyOrigin> nested = resolveEachPropertyOrigin(definition, definitions, visited);
+                Optional<EachPropertyOrigin> nested = resolveEachPropertyOrigin(definition, definitions, visited, candidatesByType);
                 if (nested.isPresent()) {
                     return nested;
                 }
@@ -685,7 +694,7 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
                 if (requiredType.isAssignableFrom(candidateType)) {
                     matched.put(candidateName, new DisabledCandidate(candidateName, entry.getValue()));
                 }
-            } catch (Throwable ignored) {
+            } catch (ClassNotFoundException | LinkageError ignored) {
             }
         }
         return matched.values().stream()

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionValidator.java
@@ -211,14 +211,14 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
             for (DependencyRequirement requirement : dependenciesOf(current)) {
                 Argument<?> argument = requirement.argument();
 
-                String unresolvedProperty = resolveMissingValueProperty(beanContext, argument);
-                if (unresolvedProperty != null) {
+                String missingPropertyMessage = resolveMissingPropertyMessage(beanContext, current, argument);
+                if (missingPropertyMessage != null) {
                     addError(
                         root,
                         current,
                         argument,
                         requirement,
-                        "Missing required property [" + unresolvedProperty + "] for @Value injection",
+                        missingPropertyMessage,
                         path,
                         errors,
                         dedupe,
@@ -440,6 +440,26 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
             || annotationMetadata.hasStereotype(Parameter.class);
     }
 
+    @Nullable
+    private static String resolveMissingPropertyMessage(
+        ConfigurableBeanContext beanContext,
+        BeanDefinition<?> current,
+        Argument<?> argument
+    ) {
+        if (isConfigurationBean(current) || !isRequiredInjection(argument)) {
+            return null;
+        }
+        String missingValueProperty = resolveMissingValueProperty(beanContext, argument);
+        if (missingValueProperty != null) {
+            return "Missing required property [" + missingValueProperty + "] for @Value injection";
+        }
+        String missingPropertyInjection = resolveMissingPropertyInjection(beanContext, argument);
+        if (missingPropertyInjection != null) {
+            return "Missing required property [" + missingPropertyInjection + "] for @Property injection";
+        }
+        return null;
+    }
+
     private static boolean hasInternalName(Argument<?> argument) {
         String name = argument.getName();
         return name.startsWith("$");
@@ -476,6 +496,26 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
             return propertyResolver.containsProperty(property) ? null : property;
         }
         return null;
+    }
+
+    @Nullable
+    private static String resolveMissingPropertyInjection(ConfigurableBeanContext beanContext, Argument<?> argument) {
+        AnnotationMetadata annotationMetadata = argument.getAnnotationMetadata();
+        if (!annotationMetadata.hasStereotype(Property.class)) {
+            return null;
+        }
+        Optional<String> propertyName = annotationMetadata.stringValue(Property.class, "name")
+            .filter(name -> !name.isBlank());
+        if (propertyName.isEmpty()) {
+            return null;
+        }
+        boolean hasDefault = annotationMetadata.stringValue(Property.class, "defaultValue")
+            .filter(defaultValue -> !defaultValue.isBlank())
+            .isPresent();
+        if (hasDefault) {
+            return null;
+        }
+        return containsProperty(beanContext, propertyName.get()) ? null : propertyName.get();
     }
 
     private static Optional<String> extractPlaceholderExpression(@Nullable String message) {

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionValidator.java
@@ -81,6 +81,7 @@ import java.util.stream.Stream;
 @Singleton
 public final class DefaultDependencyInjectionValidator implements DependencyInjectionValidator {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultDependencyInjectionValidator.class);
+    private static final String METHOD_INJECTION_POINT_PREFIX = "method ";
 
     private static final String STARTUP_EVENT = "io.micronaut.runtime.event.StartupEvent";
     private static final String SERVER_STARTUP_EVENT = "io.micronaut.runtime.server.event.ServerStartupEvent";
@@ -302,7 +303,7 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
             for (Argument<?> argument : method.getArguments()) {
                 requirements.add(new DependencyRequirement(
                     argument,
-                    "method " + definition.getBeanType().getSimpleName() + "." + method.getName() + "(" + argument.getName() + ")",
+                    METHOD_INJECTION_POINT_PREFIX + definition.getBeanType().getSimpleName() + "." + method.getName() + "(" + argument.getName() + ")",
                     methodSnippet(method, argument),
                     definition.getBeanType()
                 ));
@@ -348,7 +349,7 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
         Optional<Class<?>> declaringType = definition.getDeclaringType();
         if (constructor instanceof MethodInjectionPoint<?, ?> methodInjectionPoint) {
             Class<?> methodDeclaringType = declaringType.orElse(methodInjectionPoint.getDeclaringType());
-            return "method "
+            return METHOD_INJECTION_POINT_PREFIX
                 + methodDeclaringType.getSimpleName()
                 + "."
                 + methodInjectionPoint.getName()
@@ -367,7 +368,7 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
         if (declaringType.isPresent() && !declaringType.get().equals(definition.getBeanType())) {
             String factoryMemberName = resolveFactoryMemberName(definition);
             if (factoryMemberName != null) {
-                return "method "
+                return METHOD_INJECTION_POINT_PREFIX
                     + declaringType.get().getSimpleName()
                     + "."
                     + factoryMemberName

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionValidator.java
@@ -1,0 +1,723 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.BeanProvider;
+import io.micronaut.context.ConfigurableBeanContext;
+import io.micronaut.context.annotation.ConfigurationReader;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.env.Environment;
+import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.context.DisabledBean;
+import io.micronaut.context.Qualifier;
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Executable;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.core.annotation.EntryPoint;
+import io.micronaut.core.reflect.ClassUtils;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.TypeInformation;
+import io.micronaut.core.value.PropertyResolver;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.ConstructorInjectionPoint;
+import io.micronaut.inject.ExecutableMethod;
+import io.micronaut.inject.FieldInjectionPoint;
+import io.micronaut.inject.MethodInjectionPoint;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import jakarta.inject.Named;
+import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.HashSet;
+import java.lang.reflect.Modifier;
+import java.util.stream.Collectors;
+
+/**
+ * Default metadata-only implementation of {@link DependencyInjectionValidator}.
+ * <p>
+ * This validator inspects bean definitions and their constructor/field/method injection points
+ * to detect unresolved dependencies, missing required {@code @Value} properties, disabled-bean
+ * causes, and circular dependency paths without starting the context or instantiating beans.
+ */
+@Singleton
+public final class DefaultDependencyInjectionValidator implements DependencyInjectionValidator {
+    private static final String STARTUP_EVENT = "io.micronaut.runtime.event.StartupEvent";
+    private static final String SERVER_STARTUP_EVENT = "io.micronaut.runtime.server.event.ServerStartupEvent";
+
+    /**
+     * Validates dependency wiring for reachable roots discovered in the given context.
+     *
+     * @param beanContext The bean context to inspect
+     * @return The detected dependency-injection validation errors
+     */
+    @Override
+    public Set<DependencyInjectionError> validate(ConfigurableBeanContext beanContext) {
+        Objects.requireNonNull(beanContext, "beanContext");
+        ensureConfigured(beanContext);
+
+        Collection<BeanDefinition<Object>> definitions = beanContext.getAllBeanDefinitions();
+        if (definitions.isEmpty()) {
+            return Set.of();
+        }
+
+        Map<String, List<String>> disabledByBeanName = disabledReasonsByBeanName(beanContext.getDisabledBeans());
+        List<BeanDefinition<Object>> roots = definitions.stream()
+            .filter(this::isReachableRoot)
+            .filter(this::isConcreteRoot)
+            .sorted(Comparator.comparing(BeanDefinition::getName))
+            .toList();
+
+        Set<DependencyInjectionError> errors = new LinkedHashSet<>();
+        Set<String> dedupe = new LinkedHashSet<>();
+        for (BeanDefinition<Object> root : roots) {
+            traverse(
+                beanContext,
+                root,
+                root,
+                new LinkedHashSet<>(),
+                new ArrayList<>(),
+                errors,
+                dedupe,
+                disabledByBeanName
+            );
+        }
+        return errors;
+    }
+
+    private static void ensureConfigured(ConfigurableBeanContext beanContext) {
+        try {
+            beanContext.configure();
+        } catch (Exception ignored) {
+        }
+    }
+
+    // A reachable root is some bean that is reachable either via a startup event
+    // or via an externally reachable network like a controller or a type meta annotated
+    // with EntryPoint
+    private boolean isReachableRoot(BeanDefinition<?> definition) {
+        if (definition.hasStereotype(Context.class)) {
+            return true;
+        }
+        if (definition.hasStereotype("io.micronaut.http.annotation.Controller")) {
+            return true;
+        }
+        if (hasEntryPoint(definition)) {
+            return true;
+        }
+        return isStartupEventListener(definition);
+    }
+
+    private static boolean hasEntryPoint(BeanDefinition<?> definition) {
+        for (ExecutableMethod<?, ?> executableMethod : definition.getExecutableMethods()) {
+            if (executableMethod.hasStereotype(EntryPoint.class)) {
+                return true;
+            }
+            if (executableMethod.hasStereotype("io.micronaut.scheduling.annotation.Scheduled")) {
+                return true;
+            }
+            if (executableMethod.hasStereotype(Executable.class)
+                && executableMethod.booleanValue(Executable.class, Executable.MEMBER_PROCESS_ON_STARTUP).orElse(false)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isConcreteRoot(BeanDefinition<?> definition) {
+        Class<?> beanType = definition.getBeanType();
+        int modifiers = beanType.getModifiers();
+        return !beanType.isInterface() && !Modifier.isAbstract(modifiers);
+    }
+
+    private static boolean isStartupEventListener(BeanDefinition<?> definition) {
+        if (!ApplicationEventListener.class.isAssignableFrom(definition.getBeanType())) {
+            return false;
+        }
+        List<Argument<?>> arguments = definition.getTypeArguments(ApplicationEventListener.class);
+        if (arguments.isEmpty()) {
+            return false;
+        }
+        String eventType = arguments.getFirst().getType().getName();
+        return STARTUP_EVENT.equals(eventType) || SERVER_STARTUP_EVENT.equals(eventType);
+    }
+
+    private static Map<String, List<String>> disabledReasonsByBeanName(Collection<DisabledBean<?>> disabledBeans) {
+        Map<String, List<String>> map = new LinkedHashMap<>(disabledBeans.size());
+        for (DisabledBean<?> disabledBean : disabledBeans) {
+            map.put(disabledBean.getName(), disabledBean.reasons());
+        }
+        return map;
+    }
+
+    private void traverse(
+        ConfigurableBeanContext beanContext,
+        BeanDefinition<?> root,
+        BeanDefinition<?> current,
+        Set<String> stack,
+        List<String> path,
+        Set<DependencyInjectionError> errors,
+        Set<String> dedupe,
+        Map<String, List<String>> disabledByBeanName
+    ) {
+        String currentName = current.getName();
+        if (!stack.add(currentName)) {
+            return;
+        }
+        path.add(currentName);
+        try {
+            for (DependencyRequirement requirement : dependenciesOf(current)) {
+                Argument<?> argument = requirement.argument();
+
+                String unresolvedProperty = resolveMissingValueProperty(beanContext, argument);
+                if (unresolvedProperty != null) {
+                    addError(
+                        root,
+                        current,
+                        argument,
+                        requirement,
+                        "Missing required property [" + unresolvedProperty + "] for @Value injection",
+                        path,
+                        errors,
+                        dedupe,
+                        disabledByBeanName
+                    );
+                    continue;
+                }
+
+                if (skipInjection(requirement, argument, current)) {
+                    continue;
+                }
+
+                missingEachPropertyConfigurationKey(beanContext, argument);
+
+                Optional<BeanDefinition<?>> target;
+                try {
+                    target = findBeanDefinition(beanContext, argument, Qualifiers.forArgument(argument));
+                } catch (Exception e) {
+                    addError(
+                        root,
+                        current,
+                        argument,
+                        requirement,
+                        sanitizeMessage(e),
+                        path,
+                        errors,
+                        dedupe,
+                        disabledByBeanName
+                    );
+                    continue;
+                }
+
+                if (target.isEmpty()) {
+                    String message = missingBeanMessage(beanContext, argument, requirement, disabledByBeanName);
+                    addError(root, current, argument, requirement, message, path, errors, dedupe, disabledByBeanName);
+                    continue;
+                }
+
+                BeanDefinition<?> targetDefinition = target.get();
+                if (stack.contains(targetDefinition.getName())) {
+                    addCircularDependencyError(
+                        root,
+                        current,
+                        requirement,
+                        targetDefinition,
+                        path,
+                        errors,
+                        dedupe
+                    );
+                    continue;
+                }
+                traverse(beanContext, root, targetDefinition, stack, path, errors, dedupe, disabledByBeanName);
+            }
+        } finally {
+            path.removeLast();
+            stack.remove(currentName);
+        }
+    }
+
+    private List<DependencyRequirement> dependenciesOf(BeanDefinition<?> definition) {
+        List<DependencyRequirement> requirements = new ArrayList<>();
+
+        ConstructorInjectionPoint<?> constructor = definition.getConstructor();
+        for (Argument<?> argument : constructor.getArguments()) {
+            requirements.add(new DependencyRequirement(
+                argument,
+                "constructor " + constructorDescription(definition, argument),
+                constructorSnippet(definition, argument),
+                definition.getBeanType()
+            ));
+        }
+
+        for (FieldInjectionPoint<?, ?> field : definition.getInjectedFields()) {
+            Argument<?> argument = field.asArgument();
+            requirements.add(new DependencyRequirement(
+                argument,
+                "field " + definition.getBeanType().getSimpleName() + "." + field.getName(),
+                fieldSnippet(field, argument),
+                definition.getBeanType()
+            ));
+        }
+
+        for (MethodInjectionPoint<?, ?> method : definition.getInjectedMethods()) {
+            for (Argument<?> argument : method.getArguments()) {
+                requirements.add(new DependencyRequirement(
+                    argument,
+                    "method " + definition.getBeanType().getSimpleName() + "." + method.getName() + "(" + argument.getName() + ")",
+                    methodSnippet(method, argument),
+                    definition.getBeanType()
+                ));
+            }
+        }
+
+        return requirements;
+    }
+
+    private static String constructorSnippet(BeanDefinition<?> definition, Argument<?> argument) {
+        return definition.getBeanDescription(TypeInformation.TypeFormat.SHORTENED, false)
+            + "(" + argumentSnippet(argument) + ")";
+    }
+
+    private static String fieldSnippet(FieldInjectionPoint<?, ?> field, Argument<?> argument) {
+        return argument.getBeanTypeString(TypeInformation.TypeFormat.SHORTENED) + " " + field.getName() + ";";
+    }
+
+    private static String methodSnippet(MethodInjectionPoint<?, ?> method, Argument<?> argument) {
+        return method.getName() + "(" + argumentSnippet(argument) + ")";
+    }
+
+    private static String argumentSnippet(Argument<?> argument) {
+        return argument.getBeanTypeString(TypeInformation.TypeFormat.SHORTENED) + " " + argument.getName();
+    }
+
+    private static boolean skipInjection(DependencyRequirement requirement, Argument<?> argument, BeanDefinition<?> current) {
+        return isLazyDependency(argument)
+            || !isRequiredInjection(argument)
+            || isInternalArgument(argument)
+            || isContainerArgument(argument)
+            || isPrimitiveOrSimple(argument)
+            || isConfigurationBean(current)
+            || hasPropertyBinding(argument)
+            || hasInternalName(argument)
+            || requirement.injectionPoint().startsWith("method set");
+    }
+
+    private static String constructorDescription(BeanDefinition<?> definition, Argument<?> argument) {
+        return definition.getBeanType().getSimpleName() + "(" + argument.getName() + ")";
+    }
+
+    private static boolean isLazyDependency(Argument<?> argument) {
+        Class<?> type = argument.getType();
+        return Optional.class == type
+            || Provider.class == type
+            || BeanProvider.class == type;
+    }
+
+    private static boolean isRequiredInjection(Argument<?> argument) {
+        return !argument.isNullable();
+    }
+
+    private static boolean isInternalArgument(Argument<?> argument) {
+        String typeName = argument.getType().getName();
+        return "io.micronaut.context.BeanContext".equals(typeName)
+            || "io.micronaut.context.ApplicationContext".equals(typeName)
+            || "io.micronaut.context.BeanResolutionContext".equals(typeName)
+            || "io.micronaut.context.DefaultBeanContext".equals(typeName)
+            || "io.micronaut.context.env.Environment".equals(typeName)
+            || "io.micronaut.core.value.PropertyResolver".equals(typeName)
+            || "java.lang.ClassLoader".equals(typeName)
+            || "io.micronaut.core.convert.ConversionService".equals(typeName);
+    }
+
+    private static boolean isContainerArgument(Argument<?> argument) {
+        Class<?> type = argument.getType();
+        return type.isArray()
+            || Iterable.class.isAssignableFrom(type)
+            || java.util.Collection.class.isAssignableFrom(type)
+            || java.util.Map.class.isAssignableFrom(type)
+            || java.util.stream.Stream.class.isAssignableFrom(type);
+    }
+
+    private static boolean isPrimitiveOrSimple(Argument<?> argument) {
+        return ClassUtils.isJavaBasicType(argument.getType());
+    }
+
+    private static boolean isConfigurationBean(BeanDefinition<?> definition) {
+        return definition.hasStereotype(ConfigurationReader.class);
+    }
+
+    private static boolean hasPropertyBinding(Argument<?> argument) {
+        return argument.getAnnotationMetadata().hasStereotype(Value.class)
+            || argument.getAnnotationMetadata().hasStereotype(Property.class)
+            || argument.getAnnotationMetadata().hasStereotype(Parameter.class);
+    }
+
+    private static boolean hasInternalName(Argument<?> argument) {
+        String name = argument.getName();
+        return name.startsWith("$");
+    }
+
+    @Nullable
+    private static String resolveMissingValueProperty(ConfigurableBeanContext beanContext, Argument<?> argument) {
+        Optional<String> valueExpression;
+        try {
+            valueExpression = argument.getAnnotationMetadata().stringValue(Value.class);
+        } catch (ConfigurationException e) {
+            valueExpression = extractPlaceholderExpression(e.getMessage());
+        }
+        if (valueExpression.isEmpty()) {
+            return null;
+        }
+        String expr = valueExpression.get();
+        if (!expr.startsWith("${") || !expr.endsWith("}")) {
+            return null;
+        }
+        String inner = expr.substring(2, expr.length() - 1);
+        int colon = inner.indexOf(':');
+        String property = colon > -1 ? inner.substring(0, colon) : inner;
+        boolean hasDefault = colon > -1;
+
+        if (hasDefault) {
+            return null;
+        }
+
+        if (beanContext instanceof ApplicationContext applicationContext) {
+            return applicationContext.containsProperty(property) ? null : property;
+        }
+        if (beanContext instanceof PropertyResolver propertyResolver) {
+            return propertyResolver.containsProperty(property) ? null : property;
+        }
+        return null;
+    }
+
+    private static Optional<String> extractPlaceholderExpression(@Nullable String message) {
+        if (message == null || message.isBlank()) {
+            return Optional.empty();
+        }
+        int start = message.indexOf("${");
+        if (start < 0) {
+            return Optional.empty();
+        }
+        int end = message.indexOf('}', start + 2);
+        if (end < 0) {
+            return Optional.empty();
+        }
+        return Optional.of(message.substring(start, end + 1));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Optional<BeanDefinition<?>> findBeanDefinition(
+        ConfigurableBeanContext beanContext,
+        Argument<?> argument,
+        @Nullable Qualifier<?> qualifier
+    ) {
+        return (Optional) beanContext.findBeanDefinition((Argument) argument, (Qualifier) qualifier);
+    }
+
+    private static String missingBeanMessage(
+        ConfigurableBeanContext beanContext,
+        Argument<?> argument,
+        DependencyRequirement requirement,
+        Map<String, List<String>> disabledByBeanName
+    ) {
+        String message = "No bean of type [" + argument.getType().getName() + "] exists for " + requirement.injectionPoint();
+        Optional<String> configurationKey = missingEachPropertyConfigurationKey(beanContext, argument);
+        if (configurationKey.isPresent() && !containsProperty(beanContext, configurationKey.get())) {
+            return message + ". Bean may be non-creatable because configuration property [" + configurationKey.get() + "] is missing";
+        }
+        List<DisabledCandidate> disabledCandidates = matchingDisabledCandidates(argument, disabledByBeanName);
+        if (!disabledCandidates.isEmpty()) {
+            String candidates = disabledCandidates.stream()
+                .map(DefaultDependencyInjectionValidator::formatDisabledCandidate)
+                .collect(Collectors.joining("; "));
+            return message + ". Disabled candidate beans: " + candidates;
+        }
+        return message;
+    }
+
+    private static Optional<String> missingEachPropertyConfigurationKey(ConfigurableBeanContext beanContext, Argument<?> argument) {
+        Collection<BeanDefinition<Object>> definitions = beanContext.getAllBeanDefinitions();
+        if (definitions.isEmpty()) {
+            return Optional.empty();
+        }
+
+        for (BeanDefinition<Object> candidate : definitions) {
+            if (!argument.getType().isAssignableFrom(candidate.getBeanType())) {
+                continue;
+            }
+            if (!candidate.getAnnotationMetadata().hasStereotype(EachBean.class)) {
+                continue;
+            }
+
+            Optional<EachPropertyOrigin> origin = resolveEachPropertyOrigin(candidate, definitions, new HashSet<>());
+            if (origin.isEmpty() || origin.get().prefix().isBlank()) {
+                continue;
+            }
+
+            Optional<String> primary = origin.get().primary();
+            Optional<String> name = argument.getAnnotationMetadata().stringValue(Named.class).or(() -> primary.filter(s -> !s.isBlank()));
+            if (name.isEmpty() || name.get().isBlank()) {
+                continue;
+            }
+
+            return Optional.of(origin.get().prefix() + "." + name.get());
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<EachPropertyOrigin> resolveEachPropertyOrigin(
+        BeanDefinition<Object> candidate,
+        Collection<BeanDefinition<Object>> definitions,
+        Set<String> visited
+    ) {
+        if (!visited.add(candidate.getName())) {
+            return Optional.empty();
+        }
+
+        for (Argument<?> constructorArgument : candidate.getConstructor().getArguments()) {
+            for (BeanDefinition<Object> definition : definitions) {
+                if (!constructorArgument.getType().isAssignableFrom(definition.getBeanType())) {
+                    continue;
+                }
+                if (definition.getAnnotationMetadata().hasStereotype(EachProperty.class)) {
+                    Optional<String> prefix = definition.getAnnotationMetadata().stringValue(EachProperty.class);
+                    if (prefix.isPresent() && !prefix.get().isBlank()) {
+                        Optional<String> primary = definition.getAnnotationMetadata()
+                            .stringValue(EachProperty.class, "primary")
+                            .filter(s -> !s.isBlank());
+                        return Optional.of(new EachPropertyOrigin(prefix.get(), primary));
+                    }
+                }
+            }
+
+            for (BeanDefinition<Object> definition : definitions) {
+                if (!constructorArgument.getType().isAssignableFrom(definition.getBeanType())) {
+                    continue;
+                }
+                if (!definition.getAnnotationMetadata().hasStereotype(EachBean.class)) {
+                    continue;
+                }
+                Optional<EachPropertyOrigin> nested = resolveEachPropertyOrigin(definition, definitions, visited);
+                if (nested.isPresent()) {
+                    return nested;
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private static boolean containsProperty(ConfigurableBeanContext beanContext, String property) {
+        if (beanContext instanceof ApplicationContext applicationContext) {
+            if (applicationContext.containsProperties(property) || applicationContext.containsProperty(property)) {
+                return true;
+            }
+            Environment environment = applicationContext.getEnvironment();
+            return environment.containsProperties(property)
+                || environment.containsProperty(property);
+        }
+        if (beanContext instanceof PropertyResolver propertyResolver) {
+            return propertyResolver.containsProperties(property) || propertyResolver.containsProperty(property);
+        }
+        return false;
+    }
+
+    private static String sanitizeMessage(Throwable throwable) {
+        String message = throwable.getMessage();
+        if (message == null || message.isBlank()) {
+            return throwable.getClass().getName();
+        }
+        return message;
+    }
+
+    private void addError(
+        BeanDefinition<?> root,
+        BeanDefinition<?> current,
+        Argument<?> missingArgument,
+        DependencyRequirement requirement,
+        String message,
+        List<String> path,
+        Set<DependencyInjectionError> errors,
+        Set<String> dedupe,
+        Map<String, List<String>> disabledByBeanName
+    ) {
+        String beanName = missingArgument.getType().getName();
+        String disabledReason = findDisabledReason(missingArgument, disabledByBeanName);
+        List<String> failingPath = new ArrayList<>(path.size() + 1);
+        for (String s : path) {
+            failingPath.add("* " + s);
+        }
+        failingPath.add("* missing " + beanName + " for " + requirement.injectionPoint());
+
+        String snippet = requirement.snippet();
+        DependencyInjectionError error = new DependencyInjectionError(
+            root.getName(),
+            beanName,
+            message,
+            requirement.injectionPoint(),
+            disabledReason,
+            failingPath,
+            snippet,
+            "text"
+        );
+
+        String key = error.rootBean() + "|" + error.bean() + "|" + error.injectionPoint() + "|" + error.message();
+        if (dedupe.add(key)) {
+            errors.add(error);
+        }
+    }
+
+    private void addCircularDependencyError(
+        BeanDefinition<?> root,
+        BeanDefinition<?> current,
+        DependencyRequirement requirement,
+        BeanDefinition<?> cycleTarget,
+        List<String> path,
+        Set<DependencyInjectionError> errors,
+        Set<String> dedupe
+    ) {
+        String cycleBean = cycleTarget.getName();
+        List<String> failingPath = new ArrayList<>(path.size() + 2);
+        for (String s : path) {
+            failingPath.add("* " + s);
+        }
+        failingPath.add("* " + cycleBean);
+
+        String message = "Circular dependency detected: "
+            + String.join(" -> ", path)
+            + " -> "
+            + cycleBean
+            + " for "
+            + requirement.injectionPoint();
+
+        DependencyInjectionError error = new DependencyInjectionError(
+            root.getName(),
+            cycleBean,
+            message,
+            requirement.injectionPoint(),
+            null,
+            failingPath,
+            requirement.snippet(),
+            "text"
+        );
+
+        String key = error.rootBean() + "|" + error.bean() + "|" + error.injectionPoint() + "|" + error.message();
+        if (dedupe.add(key)) {
+            errors.add(error);
+        }
+    }
+
+    @Nullable
+    private static String findDisabledReason(Argument<?> argument, Map<String, List<String>> disabledByBeanName) {
+        List<DisabledCandidate> disabledCandidates = matchingDisabledCandidates(argument, disabledByBeanName);
+        if (!disabledCandidates.isEmpty()) {
+            return disabledCandidates.stream()
+                .map(DefaultDependencyInjectionValidator::formatDisabledCandidate)
+                .collect(Collectors.joining("; "));
+        }
+        String beanName = argument.getType().getName();
+        List<String> reasons = disabledByBeanName.get(beanName);
+        if (reasons == null || reasons.isEmpty()) {
+            for (Map.Entry<String, List<String>> entry : disabledByBeanName.entrySet()) {
+                if (entry.getKey().contains(beanName)) {
+                    reasons = entry.getValue();
+                    break;
+                }
+            }
+        }
+        if (reasons == null || reasons.isEmpty()) {
+            return null;
+        }
+        if (reasons.size() == 1) {
+            return reasons.getFirst();
+        }
+        return String.join("; ", reasons);
+    }
+
+    private static List<DisabledCandidate> matchingDisabledCandidates(
+        Argument<?> argument,
+        Map<String, List<String>> disabledByBeanName
+    ) {
+        Class<?> requiredType = argument.getType();
+        String requiredTypeName = requiredType.getName();
+        Map<String, DisabledCandidate> matched = new LinkedHashMap<>();
+        for (Map.Entry<String, List<String>> entry : disabledByBeanName.entrySet()) {
+            String candidateName = entry.getKey();
+            if (candidateName.isBlank()) {
+                continue;
+            }
+            if (candidateName.equals(requiredTypeName) || candidateName.contains(requiredTypeName)) {
+                matched.put(candidateName, new DisabledCandidate(candidateName, entry.getValue()));
+                continue;
+            }
+
+            String className = normalizeBeanClassName(candidateName);
+            try {
+                Class<?> candidateType = Class.forName(className, false, requiredType.getClassLoader());
+                if (requiredType.isAssignableFrom(candidateType)) {
+                    matched.put(candidateName, new DisabledCandidate(candidateName, entry.getValue()));
+                }
+            } catch (Throwable ignored) {
+            }
+        }
+        return matched.values().stream()
+            .sorted(Comparator.comparing(DisabledCandidate::name))
+            .toList();
+    }
+
+    private static String normalizeBeanClassName(String beanName) {
+        int dollarDollar = beanName.indexOf("$$");
+        if (dollarDollar > -1) {
+            return beanName.substring(0, dollarDollar);
+        }
+        return beanName;
+    }
+
+    private static String formatDisabledCandidate(DisabledCandidate candidate) {
+        List<String> reasons = candidate.reasons();
+        String reason = reasons.isEmpty() ? "No disable reason available" : String.join("; ", reasons);
+        return candidate.name() + " (" + reason + ")";
+    }
+
+    private record DependencyRequirement(
+        Argument<?> argument,
+        String injectionPoint,
+        String snippet,
+        Class<?> ownerType
+    ) {
+    }
+
+    private record DisabledCandidate(String name, List<String> reasons) {
+    }
+
+    private record EachPropertyOrigin(String prefix, Optional<String> primary) {
+    }
+}

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionValidator.java
@@ -16,7 +16,9 @@
 package io.micronaut.jsonschema.configuration.validator;
 
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanProvider;
+import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.context.ConfigurableBeanContext;
 import io.micronaut.context.annotation.ConfigurationReader;
 import io.micronaut.context.annotation.EachBean;
@@ -31,7 +33,9 @@ import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Executable;
 import io.micronaut.context.annotation.Value;
 import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.EntryPoint;
+import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.TypeInformation;
@@ -63,6 +67,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Default metadata-only implementation of {@link DependencyInjectionValidator}.
@@ -350,24 +355,22 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
     }
 
     private static boolean isInternalArgument(Argument<?> argument) {
-        String typeName = argument.getType().getName();
-        return "io.micronaut.context.BeanContext".equals(typeName)
-            || "io.micronaut.context.ApplicationContext".equals(typeName)
-            || "io.micronaut.context.BeanResolutionContext".equals(typeName)
-            || "io.micronaut.context.DefaultBeanContext".equals(typeName)
-            || "io.micronaut.context.env.Environment".equals(typeName)
-            || "io.micronaut.core.value.PropertyResolver".equals(typeName)
-            || "java.lang.ClassLoader".equals(typeName)
-            || "io.micronaut.core.convert.ConversionService".equals(typeName);
+        Class<?> type = argument.getType();
+        return BeanContext.class == type
+            || ApplicationContext.class == type
+            || BeanResolutionContext.class == type
+            || Environment.class == type
+            || PropertyResolver.class == type
+            || ConversionService.class == type;
     }
 
     private static boolean isContainerArgument(Argument<?> argument) {
         Class<?> type = argument.getType();
         return type.isArray()
             || Iterable.class.isAssignableFrom(type)
-            || java.util.Collection.class.isAssignableFrom(type)
-            || java.util.Map.class.isAssignableFrom(type)
-            || java.util.stream.Stream.class.isAssignableFrom(type);
+            || Collection.class.isAssignableFrom(type)
+            || Map.class.isAssignableFrom(type)
+            || Stream.class.isAssignableFrom(type);
     }
 
     private static boolean isPrimitiveOrSimple(Argument<?> argument) {
@@ -379,9 +382,10 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
     }
 
     private static boolean hasPropertyBinding(Argument<?> argument) {
-        return argument.getAnnotationMetadata().hasStereotype(Value.class)
-            || argument.getAnnotationMetadata().hasStereotype(Property.class)
-            || argument.getAnnotationMetadata().hasStereotype(Parameter.class);
+        AnnotationMetadata annotationMetadata = argument.getAnnotationMetadata();
+        return annotationMetadata.hasStereotype(Value.class)
+            || annotationMetadata.hasStereotype(Property.class)
+            || annotationMetadata.hasStereotype(Parameter.class);
     }
 
     private static boolean hasInternalName(Argument<?> argument) {

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionValidator.java
@@ -223,8 +223,6 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
                     continue;
                 }
 
-                missingEachPropertyConfigurationKey(beanContext, argument);
-
                 Optional<BeanDefinition<?>> target;
                 try {
                     target = findBeanDefinition(beanContext, argument, Qualifiers.forArgument(argument));
@@ -475,6 +473,7 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
             return Optional.empty();
         }
 
+        Map<Class<?>, List<BeanDefinition<Object>>> candidatesByType = new HashMap<>();
         for (BeanDefinition<Object> candidate : definitions) {
             if (!argument.getType().isAssignableFrom(candidate.getBeanType())) {
                 continue;
@@ -483,7 +482,7 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
                 continue;
             }
 
-            Optional<EachPropertyOrigin> origin = resolveEachPropertyOrigin(candidate, definitions, new HashSet<>(), new HashMap<>());
+            Optional<EachPropertyOrigin> origin = resolveEachPropertyOrigin(candidate, definitions, new HashSet<>(), candidatesByType);
             if (origin.isEmpty() || origin.get().prefix().isBlank()) {
                 continue;
             }

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionValidator.java
@@ -20,6 +20,7 @@ import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanProvider;
 import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.context.ConfigurableBeanContext;
+import io.micronaut.context.annotation.Secondary;
 import io.micronaut.context.annotation.ConfigurationReader;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.EachProperty;
@@ -33,9 +34,11 @@ import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Executable;
 import io.micronaut.context.annotation.Value;
 import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.context.exceptions.NonUniqueBeanException;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.EntryPoint;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.TypeInformation;
@@ -230,7 +233,7 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
 
                 Optional<BeanDefinition<?>> target;
                 try {
-                    target = findBeanDefinition(beanContext, argument, Qualifiers.forArgument(argument));
+                    target = resolveBeanDefinition(beanContext, argument, Qualifiers.forArgument(argument));
                 } catch (Exception e) {
                     addError(
                         root,
@@ -442,12 +445,88 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private static Optional<BeanDefinition<?>> findBeanDefinition(
+    private static Optional<BeanDefinition<?>> resolveBeanDefinition(
         ConfigurableBeanContext beanContext,
         Argument<?> argument,
         @Nullable Qualifier<?> qualifier
     ) {
-        return (Optional) beanContext.findBeanDefinition((Argument) argument, (Qualifier) qualifier);
+        Collection<BeanDefinition<?>> candidates = findBeanDefinitions(beanContext, argument, qualifier);
+        if (candidates.isEmpty()) {
+            return Optional.empty();
+        }
+        if (candidates.size() == 1) {
+            return Optional.of(candidates.iterator().next());
+        }
+        return Optional.of(lastChanceResolve(argument, candidates));
+    }
+
+    private static BeanDefinition<?> lastChanceResolve(Argument<?> argument, Collection<BeanDefinition<?>> candidates) {
+        Collection<BeanDefinition<?>> narrowedCandidates = candidates;
+        if (narrowedCandidates.size() > 1) {
+            List<BeanDefinition<?>> primary = narrowedCandidates.stream()
+                .filter(BeanDefinition::isPrimary)
+                .toList();
+            if (!primary.isEmpty()) {
+                narrowedCandidates = primary;
+            }
+        }
+        if (narrowedCandidates.size() == 1) {
+            return narrowedCandidates.iterator().next();
+        }
+
+        Collection<BeanDefinition<?>> originalCandidates = narrowedCandidates;
+        narrowedCandidates = narrowedCandidates.stream()
+            .filter(candidate -> !candidate.hasDeclaredStereotype(Secondary.class))
+            .toList();
+        if (narrowedCandidates.size() == 1) {
+            return narrowedCandidates.iterator().next();
+        }
+        if (narrowedCandidates.isEmpty()) {
+            throw newNonUniqueBeanException(argument, originalCandidates);
+        }
+
+        List<BeanDefinition<?>> orderedCandidates = new ArrayList<>(narrowedCandidates);
+        orderedCandidates.sort(OrderUtil.ORDERED_COMPARATOR);
+        BeanDefinition<?> bean = orderedCandidates.getFirst();
+        BeanDefinition<?> next = orderedCandidates.get(1);
+        if (bean.getOrder() != next.getOrder()) {
+            return bean;
+        }
+
+        Class<?> defaultImplementation = bean.getDefaultImplementation();
+        if (defaultImplementation != null) {
+            for (BeanDefinition<?> candidate : narrowedCandidates) {
+                if (candidate.getBeanType().equals(defaultImplementation)) {
+                    return candidate;
+                }
+            }
+        }
+
+        List<BeanDefinition<?>> exactMatches = narrowedCandidates.stream()
+            .filter(candidate -> candidate.getBeanType().equals(argument.getType()))
+            .toList();
+        if (exactMatches.size() == 1) {
+            return exactMatches.getFirst();
+        }
+
+        throw newNonUniqueBeanException(argument, narrowedCandidates);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static NonUniqueBeanException newNonUniqueBeanException(
+        Argument<?> argument,
+        Collection<BeanDefinition<?>> candidates
+    ) {
+        return new NonUniqueBeanException((Class) argument.getType(), (java.util.Iterator) candidates.iterator());
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Collection<BeanDefinition<?>> findBeanDefinitions(
+        ConfigurableBeanContext beanContext,
+        Argument<?> argument,
+        @Nullable Qualifier<?> qualifier
+    ) {
+        return (Collection) beanContext.getBeanDefinitions((Argument) argument, (Qualifier) qualifier);
     }
 
     private static String missingBeanMessage(

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DefaultDependencyInjectionValidator.java
@@ -68,6 +68,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -85,6 +86,17 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
 
     private static final String STARTUP_EVENT = "io.micronaut.runtime.event.StartupEvent";
     private static final String SERVER_STARTUP_EVENT = "io.micronaut.runtime.server.event.ServerStartupEvent";
+    private final List<ClassSuppressionMatcher> suppressedClassMatchers;
+
+    public DefaultDependencyInjectionValidator() {
+        this(List.of());
+    }
+
+    public DefaultDependencyInjectionValidator(@Nullable List<String> suppressedClassPatterns) {
+        this.suppressedClassMatchers = ClassSuppressionMatcher.compileAll(
+            suppressedClassPatterns == null ? List.of() : suppressedClassPatterns
+        );
+    }
 
     /**
      * Validates dependency wiring for reachable roots discovered in the given context.
@@ -106,6 +118,7 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
         List<BeanDefinition<Object>> roots = definitions.stream()
             .filter(this::isReachableRoot)
             .filter(this::isConcreteRoot)
+            .filter(root -> !isSuppressed(root))
             .sorted(Comparator.comparing(BeanDefinition::getName))
             .toList();
 
@@ -210,12 +223,14 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
         try {
             for (DependencyRequirement requirement : dependenciesOf(current)) {
                 Argument<?> argument = requirement.argument();
+                if (isSuppressed(argument)) {
+                    continue;
+                }
 
                 String missingPropertyMessage = resolveMissingPropertyMessage(beanContext, current, argument);
                 if (missingPropertyMessage != null) {
                     addError(
                         root,
-                        current,
                         argument,
                         requirement,
                         missingPropertyMessage,
@@ -237,7 +252,6 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
                 } catch (Exception e) {
                     addError(
                         root,
-                        current,
                         argument,
                         requirement,
                         sanitizeMessage(e),
@@ -251,15 +265,17 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
 
                 if (target.isEmpty()) {
                     String message = missingBeanMessage(beanContext, argument, requirement, disabledByBeanName);
-                    addError(root, current, argument, requirement, message, path, errors, dedupe, disabledByBeanName);
+                    addError(root, argument, requirement, message, path, errors, dedupe, disabledByBeanName);
                     continue;
                 }
 
                 BeanDefinition<?> targetDefinition = target.get();
+                if (isSuppressed(targetDefinition)) {
+                    continue;
+                }
                 if (stack.contains(targetDefinition.getName())) {
                     addCircularDependencyError(
                         root,
-                        current,
                         requirement,
                         targetDefinition,
                         path,
@@ -274,6 +290,27 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
             path.removeLast();
             stack.remove(currentName);
         }
+    }
+
+    private boolean isSuppressed(BeanDefinition<?> definition) {
+        return matchesSuppressionPattern(normalizeBeanClassName(definition.getName()))
+            || matchesSuppressionPattern(definition.getBeanType().getName());
+    }
+
+    private boolean isSuppressed(Argument<?> argument) {
+        return matchesSuppressionPattern(argument.getType().getName());
+    }
+
+    private boolean matchesSuppressionPattern(String className) {
+        if (suppressedClassMatchers.isEmpty()) {
+            return false;
+        }
+        for (ClassSuppressionMatcher matcher : suppressedClassMatchers) {
+            if (matcher.matches(className)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private List<DependencyRequirement> dependenciesOf(BeanDefinition<?> definition) {
@@ -533,7 +570,6 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
         return Optional.of(message.substring(start, end + 1));
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     private static Optional<BeanDefinition<?>> resolveBeanDefinition(
         ConfigurableBeanContext beanContext,
         Argument<?> argument,
@@ -740,7 +776,6 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
 
     private void addError(
         BeanDefinition<?> root,
-        BeanDefinition<?> current,
         Argument<?> missingArgument,
         DependencyRequirement requirement,
         String message,
@@ -777,7 +812,6 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
 
     private void addCircularDependencyError(
         BeanDefinition<?> root,
-        BeanDefinition<?> current,
         DependencyRequirement requirement,
         BeanDefinition<?> cycleTarget,
         List<String> path,
@@ -899,5 +933,44 @@ public final class DefaultDependencyInjectionValidator implements DependencyInje
     }
 
     private record EachPropertyOrigin(String prefix, Optional<String> primary) {
+    }
+
+    private interface ClassSuppressionMatcher {
+        boolean matches(String className);
+
+        static List<ClassSuppressionMatcher> compileAll(List<String> patterns) {
+            List<ClassSuppressionMatcher> matchers = new ArrayList<>(patterns.size());
+            for (String pattern : patterns) {
+                if (pattern.isBlank()) {
+                    continue;
+                }
+                matchers.add(compile(pattern));
+            }
+            return matchers;
+        }
+
+        static ClassSuppressionMatcher compile(String pattern) {
+            if (pattern.indexOf('*') > -1) {
+                Pattern regex = Pattern.compile("^" + wildcardToRegex(pattern) + "$");
+                return className -> regex.matcher(className).matches();
+            }
+            return className -> className.equals(pattern);
+        }
+
+        private static String wildcardToRegex(String wildcardPattern) {
+            StringBuilder regex = new StringBuilder(wildcardPattern.length() * 2);
+            for (int i = 0; i < wildcardPattern.length(); i++) {
+                char c = wildcardPattern.charAt(i);
+                if (c == '*') {
+                    regex.append(".*");
+                } else {
+                    if ("\\.^$|?+()[]{}".indexOf(c) != -1) {
+                        regex.append('\\');
+                    }
+                    regex.append(c);
+                }
+            }
+            return regex.toString();
+        }
     }
 }

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionError.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionError.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.core.annotation.Introspected;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Describes one dependency-injection validation failure.
+ *
+ * @param rootBean The root reachable bean where validation started
+ * @param bean The missing, disabled, or circular bean type involved in the failure
+ * @param message Human-readable error detail
+ * @param injectionPoint Injection point description (constructor, field, or method)
+ * @param disabledReason Optional reason reported by Micronaut for disabled beans
+ * @param failingPath Graph path from root bean to the failure
+ * @param snippet Best-effort snippet representing the failing injection point
+ * @param snippetLanguage Snippet language identifier
+ */
+@Introspected
+public record DependencyInjectionError(
+    String rootBean,
+    String bean,
+    String message,
+    @Nullable String injectionPoint,
+    @Nullable String disabledReason,
+    List<String> failingPath,
+    @Nullable String snippet,
+    @Nullable String snippetLanguage
+) {
+    /**
+     * Creates an immutable dependency-injection error.
+     */
+    public DependencyInjectionError {
+        failingPath = failingPath == null ? List.of() : List.copyOf(failingPath);
+    }
+}

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionErrors.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionErrors.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jsonschema.configuration.validator;
+
+import java.util.Set;
+
+/**
+ * Provides the current dependency-injection validation result set.
+ */
+public interface DependencyInjectionErrors {
+    /**
+     * Obtains the current dependency-injection errors.
+     *
+     * @return The current dependency-injection errors, or an empty set when none exist
+     */
+    Set<DependencyInjectionError> getCurrentErrors();
+}

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionValidator.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.ConfigurableBeanContext;
+
+import java.util.Set;
+
+/**
+ * Validates dependency-injection wiring using {@link io.micronaut.inject.BeanDefinition} metadata.
+ * <p>
+ * Implementations must not require the context to be started and should avoid bean instantiation.
+ */
+public interface DependencyInjectionValidator {
+    /**
+     * Validates dependency-injection relationships available in the given bean context.
+     *
+     * @param beanContext The configurable bean context to inspect
+     * @return The set of detected dependency-injection errors. Empty when no issues are found.
+     */
+    Set<DependencyInjectionError> validate(ConfigurableBeanContext beanContext);
+}

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCli.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCli.java
@@ -172,16 +172,13 @@ public final class ConfigurationJsonSchemaValidatorCli {
     }
 
     private static List<Path> discoverApplicationConfigFilesOnClasspath(String classpath) {
-        if (classpath == null || classpath.isBlank()) {
+        if (classpath.isBlank()) {
             return List.of();
         }
 
         List<Path> files = new ArrayList<>(2);
         String[] parts = classpath.split(java.util.regex.Pattern.quote(java.io.File.pathSeparator));
         for (String part : parts) {
-            if (part == null) {
-                continue;
-            }
             String trimmed = part.trim();
             if (trimmed.isEmpty()) {
                 continue;

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCli.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCli.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.json.JsonMapper;
 import io.micronaut.jsonschema.configuration.validator.ConfigurationError;
 import io.micronaut.jsonschema.configuration.validator.ConfigurationJsonSchemaValidator;
+import io.micronaut.jsonschema.configuration.validator.DependencyInjectionError;
 import io.micronaut.jsonschema.configuration.validator.report.HtmlConfigurationErrorReporter;
 import io.micronaut.jsonschema.configuration.validator.report.JsonConfigurationErrorReporter;
 import io.micronaut.jsonschema.configuration.validator.report.SystemErrConfigurationErrorReporter;
@@ -45,6 +46,7 @@ import java.util.Set;
  *     <li>{@code --suppress <pattern>} (repeatable) or {@code --suppressions <csv>}</li>
  *     <li>{@code --fail-on-not-present <true|false>} (defaults to {@code true})</li>
  *     <li>{@code --deduce-environments <true|false>} (defaults to {@code false})</li>
+ *     <li>{@code --validate-dependency-injection} (defaults to {@code false})</li>
  *     <li>{@code --out <directory>} (required)</li>
  *     <li>{@code --format <json|html|both>} (defaults to {@code both})</li>
  * </ul>
@@ -105,6 +107,7 @@ public final class ConfigurationJsonSchemaValidatorCli {
         );
 
         Set<ConfigurationError> errors;
+        Set<DependencyInjectionError> dependencyInjectionErrors = Set.of();
         try {
             errors = facade.validate();
         } catch (Exception e) {
@@ -114,22 +117,39 @@ public final class ConfigurationJsonSchemaValidatorCli {
             return 2;
         }
 
+        if (options.validateDependencyInjection()) {
+            try {
+                dependencyInjectionErrors = DependencyInjectionConfigurationValidator.forClasspath(
+                    options.classpath(),
+                    options.environments(),
+                    options.deduceEnvironments()
+                ).validate();
+            } catch (Exception e) {
+                err.println("Dependency injection validation failed while loading configuration:");
+                printDiscoveredConfigFiles(err, options.classpath());
+                printThrowable(err, e);
+                return 2;
+            }
+        }
+
         try {
-            ReportFiles reportFiles = writeReports(errors, options);
+            ReportFiles reportFiles = writeReports(errors, dependencyInjectionErrors, options);
             new SystemErrConfigurationErrorReporter(
                 err,
                 reportFiles.htmlReport(),
                 reportFiles.jsonReport(),
                 options.projectBaseDir(),
                 options.resourcesDirs()
-            ).report(errors);
+            ).report(errors, dependencyInjectionErrors);
         } catch (IOException e) {
             err.println("Failed to write report: " + e.getMessage());
             return 2;
         }
 
-        // Non-zero when any ERRORs are present.
-        return errors.stream().anyMatch(e -> e.type() == ConfigurationError.Type.ERROR) ? 1 : 0;
+        if (errors.stream().anyMatch(e -> e.type() == ConfigurationError.Type.ERROR)) {
+            return 1;
+        }
+        return dependencyInjectionErrors.isEmpty() ? 0 : 1;
     }
 
     private static void printThrowable(PrintStream err, Throwable e) {
@@ -206,20 +226,24 @@ public final class ConfigurationJsonSchemaValidatorCli {
         return message;
     }
 
-    private static ReportFiles writeReports(Set<ConfigurationError> errors, Options options) throws IOException {
+    private static ReportFiles writeReports(
+        Set<ConfigurationError> errors,
+        Set<DependencyInjectionError> dependencyInjectionErrors,
+        Options options
+    ) throws IOException {
         Path jsonFile = null;
         Path htmlFile = null;
 
         if (options.format() == Format.JSON || options.format() == Format.BOTH) {
             jsonFile = options.outDir().resolve("configuration-errors.json");
             try (OutputStream os = Files.newOutputStream(jsonFile)) {
-                new JsonConfigurationErrorReporter(JsonMapper.createDefault(), os).report(errors);
+                new JsonConfigurationErrorReporter(JsonMapper.createDefault(), os).report(errors, dependencyInjectionErrors);
             }
         }
         if (options.format() == Format.HTML || options.format() == Format.BOTH) {
             htmlFile = options.outDir().resolve("configuration-errors.html");
             try (OutputStream os = Files.newOutputStream(htmlFile)) {
-                new HtmlConfigurationErrorReporter(os).report(errors);
+                new HtmlConfigurationErrorReporter(os).report(errors, dependencyInjectionErrors);
             }
         }
         return new ReportFiles(htmlFile, jsonFile);
@@ -241,6 +265,7 @@ public final class ConfigurationJsonSchemaValidatorCli {
         List<String> suppressions,
         boolean failOnNotPresent,
         boolean deduceEnvironments,
+        boolean validateDependencyInjection,
         Path outDir,
         Format format,
         @Nullable Path projectBaseDir,
@@ -254,6 +279,7 @@ public final class ConfigurationJsonSchemaValidatorCli {
             List<String> suppressions = new ArrayList<>(0);
             boolean failOnNotPresent = true;
             boolean deduceEnvironments = false;
+            boolean validateDependencyInjection = false;
             Path outDir = null;
             Format format = Format.BOTH;
             Path projectBaseDir = null;
@@ -313,6 +339,13 @@ public final class ConfigurationJsonSchemaValidatorCli {
                         deduceEnvironments = Boolean.parseBoolean(value);
                     }
                     case "--no-deduce-environments" -> deduceEnvironments = false;
+                    case "--validate-dependency-injection" -> {
+                        if (value == null) {
+                            validateDependencyInjection = true;
+                        } else {
+                            validateDependencyInjection = Boolean.parseBoolean(value);
+                        }
+                    }
                     case "--out" -> {
                         value = value != null ? value : nextValue(list, ++i, key);
                         outDir = Path.of(value);
@@ -336,7 +369,7 @@ public final class ConfigurationJsonSchemaValidatorCli {
             }
 
             if (help) {
-                return new Options(true, "", List.of(), List.of(), true, false, Path.of("."), Format.BOTH, null, List.of());
+                return new Options(true, "", List.of(), List.of(), true, false, false, Path.of("."), Format.BOTH, null, List.of());
             }
             if (classpath == null || classpath.isBlank()) {
                 throw new IllegalArgumentException("Missing required argument: --classpath");
@@ -352,6 +385,7 @@ public final class ConfigurationJsonSchemaValidatorCli {
                 List.copyOf(suppressions),
                 failOnNotPresent,
                 deduceEnvironments,
+                validateDependencyInjection,
                 outDir,
                 format,
                 projectBaseDir,
@@ -372,6 +406,7 @@ public final class ConfigurationJsonSchemaValidatorCli {
                 "  --no-fail-on-not-present         Convenience flag to disable unknown property errors\n" +
                 "  --deduce-environments <bool>     Whether to deduce environments (default: false)\n" +
                 "  --no-deduce-environments         Convenience flag to disable environment deduction\n" +
+                "  --validate-dependency-injection  Enable dependency injection validation (default: false)\n" +
                 "  --out <dir>                      Output directory to write reports\n" +
                 "  --format <json|html|both>        Report format(s) (default: both)\n" +
                 "  --project-base-dir <dir>         Project base directory used to render relative origin paths\n" +

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCli.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCli.java
@@ -122,7 +122,8 @@ public final class ConfigurationJsonSchemaValidatorCli {
                 dependencyInjectionErrors = DependencyInjectionConfigurationValidator.forClasspath(
                     options.classpath(),
                     options.environments(),
-                    options.deduceEnvironments()
+                    options.deduceEnvironments(),
+                    options.suppressedInjectionErrors()
                 ).validate();
             } catch (Exception e) {
                 err.println("Dependency injection validation failed while loading configuration:");
@@ -260,6 +261,7 @@ public final class ConfigurationJsonSchemaValidatorCli {
         String classpath,
         List<String> environments,
         List<String> suppressions,
+        List<String> suppressedInjectionErrors,
         boolean failOnNotPresent,
         boolean deduceEnvironments,
         boolean validateDependencyInjection,
@@ -274,6 +276,7 @@ public final class ConfigurationJsonSchemaValidatorCli {
             String classpath = null;
             List<String> environments = new ArrayList<>(1);
             List<String> suppressions = new ArrayList<>(0);
+            List<String> suppressedInjectionErrors = new ArrayList<>(0);
             boolean failOnNotPresent = true;
             boolean deduceEnvironments = false;
             boolean validateDependencyInjection = false;
@@ -326,6 +329,10 @@ public final class ConfigurationJsonSchemaValidatorCli {
                         value = value != null ? value : nextValue(list, ++i, key);
                         suppressions.addAll(splitCsv(value));
                     }
+                    case "--suppress-inject-errors" -> {
+                        value = value != null ? value : nextValue(list, ++i, key);
+                        suppressedInjectionErrors.addAll(splitCsv(value));
+                    }
                     case "--fail-on-not-present" -> {
                         value = value != null ? value : nextValue(list, ++i, key);
                         failOnNotPresent = Boolean.parseBoolean(value);
@@ -366,7 +373,7 @@ public final class ConfigurationJsonSchemaValidatorCli {
             }
 
             if (help) {
-                return new Options(true, "", List.of(), List.of(), true, false, false, Path.of("."), Format.BOTH, null, List.of());
+                return new Options(true, "", List.of(), List.of(), List.of(), true, false, false, Path.of("."), Format.BOTH, null, List.of());
             }
             if (classpath == null || classpath.isBlank()) {
                 throw new IllegalArgumentException("Missing required argument: --classpath");
@@ -380,6 +387,7 @@ public final class ConfigurationJsonSchemaValidatorCli {
                 classpath,
                 List.copyOf(environments),
                 List.copyOf(suppressions),
+                List.copyOf(suppressedInjectionErrors),
                 failOnNotPresent,
                 deduceEnvironments,
                 validateDependencyInjection,
@@ -399,6 +407,7 @@ public final class ConfigurationJsonSchemaValidatorCli {
                 "  --environments <csv>             Comma-separated environments\n" +
                 "  --suppress <pattern>             Suppression pattern (repeatable)\n" +
                 "  --suppressions <csv>             Comma-separated suppression patterns\n" +
+                "  --suppress-inject-errors <csv>   Comma-separated DI class-name suppression patterns\n" +
                 "  --fail-on-not-present <bool>     Whether unknown properties are errors (default: true)\n" +
                 "  --no-fail-on-not-present         Convenience flag to disable unknown property errors\n" +
                 "  --deduce-environments <bool>     Whether to deduce environments (default: false)\n" +
@@ -454,4 +463,5 @@ public final class ConfigurationJsonSchemaValidatorCli {
             };
         }
     }
+
 }

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliBootstrap.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliBootstrap.java
@@ -92,9 +92,6 @@ public final class ConfigurationJsonSchemaValidatorCliBootstrap {
         String[] parts = classpath.split(Pattern.quote(File.pathSeparator));
         List<URL> urls = new ArrayList<>(parts.length);
         for (String part : parts) {
-            if (part == null) {
-                continue;
-            }
             String trimmed = part.trim();
             if (trimmed.isEmpty()) {
                 continue;
@@ -112,9 +109,6 @@ public final class ConfigurationJsonSchemaValidatorCliBootstrap {
     private static String parseClasspathArg(String[] args) {
         for (int i = 0; i < args.length; i++) {
             String arg = args[i];
-            if (arg == null) {
-                continue;
-            }
 
             String equalsValue = parseEqualsSyntax(arg);
             if (equalsValue != null) {
@@ -147,9 +141,6 @@ public final class ConfigurationJsonSchemaValidatorCliBootstrap {
             return null;
         }
         String next = args[index + 1];
-        if (next == null) {
-            return "";
-        }
         if (next.startsWith("-")) {
             return null;
         }

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/DependencyInjectionConfigurationValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/DependencyInjectionConfigurationValidator.java
@@ -17,10 +17,13 @@ package io.micronaut.jsonschema.configuration.validator.cli;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.ConfigurableApplicationContext;
+import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.jsonschema.configuration.validator.DefaultDependencyInjectionValidator;
 import io.micronaut.jsonschema.configuration.validator.DependencyInjectionError;
 import io.micronaut.jsonschema.configuration.validator.DependencyInjectionValidator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -30,6 +33,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * CLI-oriented dependency-injection validator that builds an application context from a supplied
@@ -37,7 +41,7 @@ import java.util.Set;
  */
 @Internal
 public final class DependencyInjectionConfigurationValidator {
-    private static final System.Logger LOG = System.getLogger(DependencyInjectionConfigurationValidator.class.getName());
+    private static final Logger LOG = LoggerFactory.getLogger(DependencyInjectionConfigurationValidator.class.getName());
 
     private final List<URL> classpath;
     private final List<String> environments;
@@ -90,17 +94,15 @@ public final class DependencyInjectionConfigurationValidator {
      */
     public Set<DependencyInjectionError> validate() {
         try (URLClassLoader classLoader = new URLClassLoader(classpath.toArray(URL[]::new), JsonSchemaConfigurationValidator.class.getClassLoader())) {
-            ApplicationContext context = ApplicationContext.builder(environments.toArray(String[]::new))
+            try (ApplicationContext context = ApplicationContext.builder(environments.toArray(String[]::new))
                 .classLoader(classLoader)
                 .deduceEnvironment(deduceEnvironment)
-                .build();
-            try {
+                .build()) {
                 ConfigurableApplicationContext configurableContext = (ConfigurableApplicationContext) context;
-                configurableContext.getEnvironment().start();
-                configurableContext.configure();
-                return validator.validate(configurableContext);
-            } finally {
-                context.close();
+                try (Environment ignore = configurableContext.getEnvironment().start()) {
+                    configurableContext.configure();
+                    return validator.validate(configurableContext);
+                }
             }
         } catch (Exception e) {
             throw new IllegalStateException("Dependency injection validation failed", e);
@@ -108,12 +110,9 @@ public final class DependencyInjectionConfigurationValidator {
     }
 
     private static List<URL> parseClasspath(String classpath) {
-        String[] parts = classpath.split(java.util.regex.Pattern.quote(File.pathSeparator));
+        String[] parts = classpath.split(Pattern.quote(File.pathSeparator));
         List<URL> urls = new ArrayList<>(parts.length);
         for (String part : parts) {
-            if (part == null) {
-                continue;
-            }
             String trimmed = part.trim();
             if (trimmed.isEmpty()) {
                 continue;
@@ -121,7 +120,7 @@ public final class DependencyInjectionConfigurationValidator {
             try {
                 urls.add(Path.of(trimmed).toUri().toURL());
             } catch (MalformedURLException e) {
-                LOG.log(System.Logger.Level.DEBUG, "Invalid classpath entry: " + trimmed, e);
+                LOG.debug("Invalid classpath entry: " + trimmed, e);
             }
         }
         return urls;

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/DependencyInjectionConfigurationValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/DependencyInjectionConfigurationValidator.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jsonschema.configuration.validator.cli;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.ConfigurableApplicationContext;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.jsonschema.configuration.validator.DefaultDependencyInjectionValidator;
+import io.micronaut.jsonschema.configuration.validator.DependencyInjectionError;
+import io.micronaut.jsonschema.configuration.validator.DependencyInjectionValidator;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * CLI-oriented dependency-injection validator that builds an application context from a supplied
+ * runtime classpath and environment set, then validates bean wiring metadata.
+ */
+@Internal
+public final class DependencyInjectionConfigurationValidator {
+    private static final System.Logger LOG = System.getLogger(DependencyInjectionConfigurationValidator.class.getName());
+
+    private final List<URL> classpath;
+    private final List<String> environments;
+    private final boolean deduceEnvironment;
+    private final DependencyInjectionValidator validator;
+
+    /**
+     * @param classpath Runtime classpath URLs used to create the validation classloader
+     * @param environments Environment names passed to {@link ApplicationContext#builder(String...)}
+     * @param deduceEnvironment Whether Micronaut should deduce environments
+     * @param validator The dependency-injection validator implementation
+     */
+    public DependencyInjectionConfigurationValidator(
+        List<URL> classpath,
+        List<String> environments,
+        boolean deduceEnvironment,
+        DependencyInjectionValidator validator
+    ) {
+        this.classpath = List.copyOf(classpath);
+        this.environments = List.copyOf(environments);
+        this.deduceEnvironment = deduceEnvironment;
+        this.validator = validator;
+    }
+
+    /**
+     * Creates a validator from a platform classpath string.
+     *
+     * @param classpath The classpath string using the platform path separator
+     * @param environments The environment names to activate
+     * @param deduceEnvironment Whether environment deduction is enabled
+     * @return A configured validator instance
+     */
+    public static DependencyInjectionConfigurationValidator forClasspath(
+        String classpath,
+        List<String> environments,
+        boolean deduceEnvironment
+    ) {
+        return new DependencyInjectionConfigurationValidator(
+            parseClasspath(classpath),
+            environments,
+            deduceEnvironment,
+            new DefaultDependencyInjectionValidator()
+        );
+    }
+
+    /**
+     * Executes dependency-injection validation for the configured classpath and environments.
+     *
+     * @return The set of detected dependency-injection errors
+     */
+    public Set<DependencyInjectionError> validate() {
+        try (URLClassLoader classLoader = new URLClassLoader(classpath.toArray(URL[]::new), JsonSchemaConfigurationValidator.class.getClassLoader())) {
+            ApplicationContext context = ApplicationContext.builder(environments.toArray(String[]::new))
+                .classLoader(classLoader)
+                .deduceEnvironment(deduceEnvironment)
+                .build();
+            try {
+                ConfigurableApplicationContext configurableContext = (ConfigurableApplicationContext) context;
+                configurableContext.configure();
+                return validator.validate(configurableContext);
+            } finally {
+                context.close();
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("Dependency injection validation failed", e);
+        }
+    }
+
+    private static List<URL> parseClasspath(String classpath) {
+        String[] parts = classpath.split(java.util.regex.Pattern.quote(File.pathSeparator));
+        List<URL> urls = new ArrayList<>(parts.length);
+        for (String part : parts) {
+            if (part == null) {
+                continue;
+            }
+            String trimmed = part.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            try {
+                urls.add(Path.of(trimmed).toUri().toURL());
+            } catch (MalformedURLException e) {
+                LOG.log(System.Logger.Level.DEBUG, "Invalid classpath entry: " + trimmed, e);
+            }
+        }
+        return urls;
+    }
+}

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/DependencyInjectionConfigurationValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/DependencyInjectionConfigurationValidator.java
@@ -79,11 +79,20 @@ public final class DependencyInjectionConfigurationValidator {
         List<String> environments,
         boolean deduceEnvironment
     ) {
+        return forClasspath(classpath, environments, deduceEnvironment, List.of());
+    }
+
+    public static DependencyInjectionConfigurationValidator forClasspath(
+        String classpath,
+        List<String> environments,
+        boolean deduceEnvironment,
+        List<String> suppressedInjectionErrors
+    ) {
         return new DependencyInjectionConfigurationValidator(
             parseClasspath(classpath),
             environments,
             deduceEnvironment,
-            new DefaultDependencyInjectionValidator()
+            new DefaultDependencyInjectionValidator(suppressedInjectionErrors)
         );
     }
 

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/DependencyInjectionConfigurationValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/DependencyInjectionConfigurationValidator.java
@@ -96,6 +96,7 @@ public final class DependencyInjectionConfigurationValidator {
                 .build();
             try {
                 ConfigurableApplicationContext configurableContext = (ConfigurableApplicationContext) context;
+                configurableContext.getEnvironment().start();
                 configurableContext.configure();
                 return validator.validate(configurableContext);
             } finally {

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/DependencyInjectionConfigurationValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/DependencyInjectionConfigurationValidator.java
@@ -22,8 +22,6 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.jsonschema.configuration.validator.DefaultDependencyInjectionValidator;
 import io.micronaut.jsonschema.configuration.validator.DependencyInjectionError;
 import io.micronaut.jsonschema.configuration.validator.DependencyInjectionValidator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -41,7 +39,7 @@ import java.util.regex.Pattern;
  */
 @Internal
 public final class DependencyInjectionConfigurationValidator {
-    private static final Logger LOG = LoggerFactory.getLogger(DependencyInjectionConfigurationValidator.class.getName());
+    private static final System.Logger LOG = System.getLogger(DependencyInjectionConfigurationValidator.class.getName());
 
     private final List<URL> classpath;
     private final List<String> environments;
@@ -129,7 +127,7 @@ public final class DependencyInjectionConfigurationValidator {
             try {
                 urls.add(Path.of(trimmed).toUri().toURL());
             } catch (MalformedURLException e) {
-                LOG.debug("Invalid classpath entry: " + trimmed, e);
+                LOG.log(System.Logger.Level.DEBUG, "Invalid classpath entry: " + trimmed, e);
             }
         }
         return urls;

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/JsonSchemaConfigurationValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/JsonSchemaConfigurationValidator.java
@@ -22,6 +22,8 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.jsonschema.configuration.validator.ConfigurationError;
 import io.micronaut.jsonschema.configuration.validator.ConfigurationJsonSchemaValidator;
 import io.micronaut.jsonschema.configuration.validator.report.ConfigurationErrorReporter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -39,7 +41,7 @@ import java.util.Set;
  */
 @Internal
 public final class JsonSchemaConfigurationValidator {
-    private static final System.Logger LOG = System.getLogger(JsonSchemaConfigurationValidator.class.getName());
+    private static final Logger LOG = LoggerFactory.getLogger(JsonSchemaConfigurationValidator.class.getName());
 
     private final List<URL> classpath;
     private final List<String> environments;
@@ -123,9 +125,6 @@ public final class JsonSchemaConfigurationValidator {
         String[] parts = classpath.split(java.util.regex.Pattern.quote(File.pathSeparator));
         List<URL> urls = new ArrayList<>(parts.length);
         for (String part : parts) {
-            if (part == null) {
-                continue;
-            }
             String trimmed = part.trim();
             if (trimmed.isEmpty()) {
                 continue;
@@ -133,7 +132,7 @@ public final class JsonSchemaConfigurationValidator {
             try {
                 urls.add(Path.of(trimmed).toUri().toURL());
             } catch (MalformedURLException e) {
-                LOG.log(System.Logger.Level.DEBUG, "Invalid classpath entry: " + trimmed, e);
+                LOG.debug("Invalid classpath entry: " + trimmed, e);
             }
         }
         return urls;

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/JsonSchemaConfigurationValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/cli/JsonSchemaConfigurationValidator.java
@@ -22,8 +22,6 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.jsonschema.configuration.validator.ConfigurationError;
 import io.micronaut.jsonschema.configuration.validator.ConfigurationJsonSchemaValidator;
 import io.micronaut.jsonschema.configuration.validator.report.ConfigurationErrorReporter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,7 +39,7 @@ import java.util.Set;
  */
 @Internal
 public final class JsonSchemaConfigurationValidator {
-    private static final Logger LOG = LoggerFactory.getLogger(JsonSchemaConfigurationValidator.class.getName());
+    private static final System.Logger LOG = System.getLogger(JsonSchemaConfigurationValidator.class.getName());
 
     private final List<URL> classpath;
     private final List<String> environments;
@@ -132,7 +130,7 @@ public final class JsonSchemaConfigurationValidator {
             try {
                 urls.add(Path.of(trimmed).toUri().toURL());
             } catch (MalformedURLException e) {
-                LOG.debug("Invalid classpath entry: " + trimmed, e);
+                LOG.log(System.Logger.Level.DEBUG, "Invalid classpath entry: " + trimmed, e);
             }
         }
         return urls;

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/management/InjectErrorsEndpoint.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/management/InjectErrorsEndpoint.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jsonschema.configuration.validator.management;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.jsonschema.configuration.validator.ConfigurationValidatorConfiguration;
+import io.micronaut.jsonschema.configuration.validator.DependencyInjectionErrors;
+import io.micronaut.management.endpoint.annotation.Endpoint;
+import io.micronaut.management.endpoint.annotation.Read;
+import jakarta.inject.Singleton;
+
+import java.util.Map;
+
+@Requires(classes = Endpoint.class)
+@Requires(property = ConfigurationValidatorConfiguration.PREFIX + ".dependency-injection.enabled", value = StringUtils.TRUE)
+@Requires(property = ConfigurationValidatorConfiguration.PREFIX + ".injecterrors.endpoint.enabled", value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
+@Endpoint(id = "injecterrors")
+@Singleton
+final class InjectErrorsEndpoint {
+    private final DependencyInjectionErrors dependencyInjectionErrors;
+
+    InjectErrorsEndpoint(DependencyInjectionErrors dependencyInjectionErrors) {
+        this.dependencyInjectionErrors = dependencyInjectionErrors;
+    }
+
+    @Read
+    Map<String, Object> getErrors() {
+        return Map.of("errors", dependencyInjectionErrors.getCurrentErrors());
+    }
+}

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/management/InjectErrorsHealthIndicator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/management/InjectErrorsHealthIndicator.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jsonschema.configuration.validator.management;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.health.HealthStatus;
+import io.micronaut.jsonschema.configuration.validator.ConfigurationValidatorConfiguration;
+import io.micronaut.jsonschema.configuration.validator.DependencyInjectionError;
+import io.micronaut.jsonschema.configuration.validator.DependencyInjectionErrors;
+import io.micronaut.management.health.indicator.HealthIndicator;
+import io.micronaut.management.health.indicator.HealthResult;
+import jakarta.inject.Singleton;
+import org.reactivestreams.Publisher;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Requires(classes = HealthIndicator.class)
+@Requires(property = ConfigurationValidatorConfiguration.PREFIX + ".dependency-injection.enabled", value = StringUtils.TRUE)
+@Singleton
+final class InjectErrorsHealthIndicator implements HealthIndicator {
+    private static final String NAME = "injecterrors";
+    private static final int MAX_INCLUDED_ERRORS = 10;
+    private final DependencyInjectionErrors dependencyInjectionErrors;
+
+    InjectErrorsHealthIndicator(DependencyInjectionErrors dependencyInjectionErrors) {
+        this.dependencyInjectionErrors = dependencyInjectionErrors;
+    }
+
+    @Override
+    public Publisher<HealthResult> getResult() {
+        Set<DependencyInjectionError> errors = dependencyInjectionErrors.getCurrentErrors();
+        List<DependencyInjectionError> errorList = errors.stream()
+            .sorted(Comparator.comparing(DependencyInjectionError::rootBean).thenComparing(DependencyInjectionError::bean))
+            .toList();
+
+        HealthResult.Builder builder = HealthResult.builder(NAME);
+        Map<String, Object> details = new LinkedHashMap<>(3);
+        details.put("errorCount", errorList.size());
+
+        if (!errorList.isEmpty()) {
+            builder.status(HealthStatus.DOWN);
+            List<Map<String, Object>> included = new ArrayList<>(Math.min(MAX_INCLUDED_ERRORS, errorList.size()));
+            for (int i = 0; i < errorList.size() && i < MAX_INCLUDED_ERRORS; i++) {
+                included.add(errorToDetails(errorList.get(i)));
+            }
+            details.put("errors", included);
+            if (errorList.size() > MAX_INCLUDED_ERRORS) {
+                details.put("truncated", true);
+            }
+        } else {
+            builder.status(HealthStatus.UP);
+        }
+        builder.details(details);
+        return Publishers.just(builder.build());
+    }
+
+    private static Map<String, Object> errorToDetails(DependencyInjectionError error) {
+        Map<String, Object> details = new LinkedHashMap<>(8);
+        details.put("rootBean", error.rootBean());
+        details.put("bean", error.bean());
+        details.put("message", error.message());
+        if (error.injectionPoint() != null) {
+            details.put("injectionPoint", error.injectionPoint());
+        }
+        if (error.disabledReason() != null) {
+            details.put("disabledReason", error.disabledReason());
+        }
+        if (!error.failingPath().isEmpty()) {
+            details.put("failingPath", error.failingPath());
+        }
+        return details;
+    }
+}

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/management/InjectErrorsHealthIndicator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/management/InjectErrorsHealthIndicator.java
@@ -36,6 +36,7 @@ import java.util.Set;
 
 @Requires(classes = HealthIndicator.class)
 @Requires(property = ConfigurationValidatorConfiguration.PREFIX + ".dependency-injection.enabled", value = StringUtils.TRUE)
+@Requires(property = ConfigurationValidatorConfiguration.ENDPOINT_PREFIX + ".enabled", value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
 @Singleton
 final class InjectErrorsHealthIndicator implements HealthIndicator {
     private static final String NAME = "injecterrors";

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/ConfigurationErrorReporter.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/ConfigurationErrorReporter.java
@@ -16,8 +16,10 @@
 package io.micronaut.jsonschema.configuration.validator.report;
 
 import io.micronaut.jsonschema.configuration.validator.ConfigurationError;
+import io.micronaut.jsonschema.configuration.validator.DependencyInjectionError;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -30,5 +32,9 @@ public interface ConfigurationErrorReporter {
      * @param errors The errors to report
      * @throws IOException If the reporter fails to write the report
      */
-    void report(Set<ConfigurationError> errors) throws IOException;
+    default void report(Set<ConfigurationError> errors) throws IOException {
+        report(errors, Collections.emptySet());
+    }
+
+    void report(Set<ConfigurationError> errors, Set<DependencyInjectionError> dependencyInjectionErrors) throws IOException;
 }

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/HtmlConfigurationErrorReporter.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/HtmlConfigurationErrorReporter.java
@@ -32,6 +32,7 @@ import java.util.Set;
 /**
  * Reports errors as an HTML document.
  */
+@SuppressWarnings("java:S1192")
 public final class HtmlConfigurationErrorReporter implements ConfigurationErrorReporter {
     private static final String HTML_DIV_CLOSE = "</div>";
     private static final String HTML_DIV_DIV_CLOSE = "</div></div>";
@@ -50,6 +51,7 @@ public final class HtmlConfigurationErrorReporter implements ConfigurationErrorR
     }
 
     @Override
+    @SuppressWarnings("java:S3776")
     public void report(Set<ConfigurationError> errors, Set<DependencyInjectionError> dependencyInjectionErrors) throws IOException {
         long errorCount = errors.stream().filter(e -> e.type() == ConfigurationError.Type.ERROR).count();
         long warningCount = errors.stream().filter(e -> e.type() == ConfigurationError.Type.WARNING).count();
@@ -246,13 +248,13 @@ public final class HtmlConfigurationErrorReporter implements ConfigurationErrorR
         output.flush();
     }
 
-    private static String shortName(String typeName) {
+    private static String shortName(@Nullable String typeName) {
         return typeName == null ? "" : NameUtils.getShortenedName(typeName);
     }
 
     private static String failurePathGraphDataUri(DependencyInjectionError error) {
         List<String> nodes = normalizedPathNodes(error);
-        String svg = renderPathSvg(nodes);
+        String svg = renderPathSvg(nodes, Integer.toHexString(error.hashCode()));
         String encoded = Base64.getEncoder().encodeToString(svg.getBytes(StandardCharsets.UTF_8));
         return "data:image/svg+xml;base64," + encoded;
     }
@@ -268,7 +270,7 @@ public final class HtmlConfigurationErrorReporter implements ConfigurationErrorR
         return nodes;
     }
 
-    private static String cleanPathNode(String pathEntry) {
+    private static String cleanPathNode(@Nullable String pathEntry) {
         if (pathEntry == null) {
             return "";
         }
@@ -279,17 +281,18 @@ public final class HtmlConfigurationErrorReporter implements ConfigurationErrorR
         return cleaned;
     }
 
-    private static String renderPathSvg(List<String> nodes) {
+    private static String renderPathSvg(List<String> nodes, String idSuffix) {
         int width = 960;
         int headerHeight = 24;
         int rowHeight = 50;
         int height = Math.max(140, headerHeight + (nodes.size() * rowHeight) + 30);
 
+        String markerId = "arrow-" + idSuffix;
         StringBuilder svg = new StringBuilder(1024);
         svg.append("<svg xmlns='http://www.w3.org/2000/svg' width='").append(width).append("' height='").append(height).append("' viewBox='0 0 ")
             .append(width).append(' ').append(height).append("'>")
             .append("<rect width='100%' height='100%' fill='#ffffff'/>")
-            .append("<defs><marker id='arrow' markerWidth='10' markerHeight='8' refX='9' refY='4' orient='auto'>")
+            .append("<defs><marker id='").append(markerId).append("' markerWidth='10' markerHeight='8' refX='9' refY='4' orient='auto'>")
             .append("<polygon points='0 0, 10 4, 0 8' fill='#475467'/></marker></defs>");
 
         int x = 24;
@@ -301,14 +304,14 @@ public final class HtmlConfigurationErrorReporter implements ConfigurationErrorR
                 .append("' rx='6' ry='6' fill='#f8f9fb' stroke='#d0d5dd'/>")
                 .append("<text x='").append(x + 10).append("' y='").append(y + 20)
                 .append("' font-family='ui-monospace, SFMono-Regular, Menlo, monospace' font-size='12' fill='#101828'>")
-                .append(escapeSvg(nodes.get(i))).append("</text>");
+                .append(escapeSvg(truncateForSvg(nodes.get(i), 118))).append("</text>");
 
             if (i < nodes.size() - 1) {
                 int lineY1 = y + boxHeight;
                 int lineY2 = y + rowHeight - 6;
                 int lineX = x + (boxWidth / 2);
                 svg.append("<line x1='").append(lineX).append("' y1='").append(lineY1).append("' x2='").append(lineX).append("' y2='").append(lineY2)
-                    .append("' stroke='#475467' stroke-width='1.5' marker-end='url(#arrow)'/>");
+                    .append("' stroke='#475467' stroke-width='1.5' marker-end='url(#").append(markerId).append(")'/>");
             }
             y += rowHeight;
         }
@@ -318,6 +321,16 @@ public final class HtmlConfigurationErrorReporter implements ConfigurationErrorR
 
     private static String escapeSvg(String value) {
         return escape(value);
+    }
+
+    private static String truncateForSvg(String value, int maxChars) {
+        if (value.length() <= maxChars) {
+            return value;
+        }
+        if (maxChars < 4) {
+            return value.substring(0, maxChars);
+        }
+        return value.substring(0, maxChars - 3) + "...";
     }
 
     private static String formatDetails(String message, @Nullable String disabledReason) {

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/HtmlConfigurationErrorReporter.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/HtmlConfigurationErrorReporter.java
@@ -16,11 +16,17 @@
 package io.micronaut.jsonschema.configuration.validator.report;
 
 import io.micronaut.jsonschema.configuration.validator.ConfigurationError;
+import io.micronaut.jsonschema.configuration.validator.DependencyInjectionError;
+import io.micronaut.core.naming.NameUtils;
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -44,9 +50,10 @@ public final class HtmlConfigurationErrorReporter implements ConfigurationErrorR
     }
 
     @Override
-    public void report(Set<ConfigurationError> errors) throws IOException {
+    public void report(Set<ConfigurationError> errors, Set<DependencyInjectionError> dependencyInjectionErrors) throws IOException {
         long errorCount = errors.stream().filter(e -> e.type() == ConfigurationError.Type.ERROR).count();
         long warningCount = errors.stream().filter(e -> e.type() == ConfigurationError.Type.WARNING).count();
+        long dependencyInjectionErrorCount = dependencyInjectionErrors.size();
 
         StringBuilder html = new StringBuilder(8192);
         html.append("<!doctype html><html lang='en'><head><meta charset='utf-8'>")
@@ -69,6 +76,8 @@ public final class HtmlConfigurationErrorReporter implements ConfigurationErrorR
             .append(".col-raw{width:13%;}")
             .append(".col-value{width:13%;}")
             .append(".mn-wrap{word-break:break-word;white-space:normal;}")
+            .append(".mn-detail-main{margin-bottom:.25rem;}")
+            .append(".mn-detail-list{margin:.5rem 0 0 1rem;padding-left:.6rem;}")
             .append("pre{margin:0;}")
             .append("code.hljs{padding:12px;border-radius:8px;}")
             .append("</style>")
@@ -98,9 +107,13 @@ public final class HtmlConfigurationErrorReporter implements ConfigurationErrorR
             .append("<div class='text-secondary small'>Warnings</div>")
             .append("<div class='h4 mb-0 text-warning'>").append(warningCount).append(HTML_DIV_CLOSE)
             .append(HTML_DIV_DIV_CLOSE)
+            .append(HTML_CARD_OPEN)
+            .append("<div class='text-secondary small'>Dependency Injection Errors</div>")
+            .append("<div class='h4 mb-0 text-danger'>").append(dependencyInjectionErrorCount).append(HTML_DIV_CLOSE)
+            .append(HTML_DIV_DIV_CLOSE)
             .append(HTML_DIV_CLOSE);
 
-        if (errors.isEmpty()) {
+        if (errors.isEmpty() && dependencyInjectionErrors.isEmpty()) {
             html.append("<div class='alert alert-success' role='alert'>No configuration validation errors.</div>")
                 .append("</main></body></html>");
 
@@ -109,7 +122,8 @@ public final class HtmlConfigurationErrorReporter implements ConfigurationErrorR
             return;
         }
 
-        html.append("<div class='table-responsive'>")
+        html.append("<h2 class='h5 mb-3'>Configuration errors</h2>")
+            .append("<div class='table-responsive'>")
             .append("<table class='table table-striped table-hover align-middle table-fixed'>")
             .append("<thead class='table-light'><tr>")
             .append("<th class='col-prop'>Property</th>")
@@ -157,13 +171,210 @@ public final class HtmlConfigurationErrorReporter implements ConfigurationErrorR
         }
 
         html.append("</tbody></table></div>")
-            .append("</main>")
+            .append("<h2 class='h5 mt-4 mb-3'>Dependency injection errors</h2>")
+            .append("<div class='table-responsive'>")
+            .append("<table class='table table-striped table-hover align-middle table-fixed'>")
+            .append("<thead class='table-light'><tr>")
+            .append("<th style='width:24%'>Injection Point</th>")
+            .append("<th style='width:16%'>Bean</th>")
+            .append("<th style='width:42%'>Details</th>")
+            .append("<th style='width:18%'>Snippet</th>")
+            .append("</tr></thead><tbody>");
+
+        if (dependencyInjectionErrors.isEmpty()) {
+            html.append("<tr><td colspan='4' class='text-secondary'>No dependency injection validation errors.</td></tr>");
+        } else {
+            for (DependencyInjectionError error : dependencyInjectionErrors) {
+                html.append("<tr>")
+                    .append(HTML_TD_CODE_OPEN).append(escape(error.injectionPoint())).append(HTML_TD_CODE_CLOSE)
+                    .append(HTML_TD_CODE_OPEN).append(escape(shortName(error.bean()))).append(HTML_TD_CODE_CLOSE)
+                    .append(renderDetailsCell(error));
+
+                String snippet = error.snippet();
+                if (snippet != null && !snippet.isBlank()) {
+                    String language = error.snippetLanguage() != null ? error.snippetLanguage() : "plaintext";
+                    html.append("<td>")
+                        .append("<details>")
+                        .append("<summary>View</summary>")
+                        .append("<div class='mt-2'>")
+                        .append("<pre><code class='hljs language-").append(escape(language)).append("'>")
+                        .append(escape(snippet))
+                        .append("</code></pre>")
+                        .append(HTML_DIV_CLOSE)
+                        .append("</details>")
+                        .append(HTML_TD_CLOSE);
+                } else {
+                    html.append("<td class='text-secondary'>-</td>");
+                }
+
+                html.append("</tr>");
+            }
+        }
+
+        html.append("</tbody></table></div>")
+            .append("<h2 class='h5 mt-4 mb-3'>Dependency injection failure paths</h2>");
+
+        if (dependencyInjectionErrors.isEmpty()) {
+            html.append("<div class='text-secondary'>No failing dependency injection paths.</div>");
+        } else {
+            for (DependencyInjectionError error : dependencyInjectionErrors) {
+                html.append("<details class='mb-2'><summary><code>")
+                    .append(escape(error.rootBean()))
+                    .append("</code></summary>")
+                    .append("<pre class='mt-2'><code class='hljs language-plaintext'>");
+                if (error.failingPath().isEmpty()) {
+                    html.append(escape(error.bean())).append(" (failed)");
+                } else {
+                    for (String pathEntry : error.failingPath()) {
+                        html.append(escape(pathEntry)).append('\n');
+                    }
+                }
+                html.append("</code></pre>")
+                    .append("<div class='mt-2'><img alt='Dependency injection graph' class='img-fluid border rounded p-2 bg-white' src='")
+                    .append(escape(failurePathGraphDataUri(error)))
+                    .append("'></div>")
+                    .append("</details>");
+            }
+        }
+
+        html.append("</main>")
             .append("<script src='https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js'></script>")
             .append("<script>try{hljs.highlightAll();}catch(e){}</script>")
             .append("</body></html>");
 
         output.write(html.toString().getBytes(StandardCharsets.UTF_8));
         output.flush();
+    }
+
+    private static String shortName(String typeName) {
+        return typeName == null ? "" : NameUtils.getShortenedName(typeName);
+    }
+
+    private static String failurePathGraphDataUri(DependencyInjectionError error) {
+        List<String> nodes = normalizedPathNodes(error);
+        String svg = renderPathSvg(nodes);
+        String encoded = Base64.getEncoder().encodeToString(svg.getBytes(StandardCharsets.UTF_8));
+        return "data:image/svg+xml;base64," + encoded;
+    }
+
+    private static List<String> normalizedPathNodes(DependencyInjectionError error) {
+        if (error.failingPath().isEmpty()) {
+            return List.of(error.rootBean(), error.bean() + " (failed)");
+        }
+        List<String> nodes = new ArrayList<>(error.failingPath().size());
+        for (String pathEntry : error.failingPath()) {
+            nodes.add(cleanPathNode(pathEntry));
+        }
+        return nodes;
+    }
+
+    private static String cleanPathNode(String pathEntry) {
+        if (pathEntry == null) {
+            return "";
+        }
+        String cleaned = pathEntry.trim();
+        if (cleaned.startsWith("*")) {
+            cleaned = cleaned.substring(1).trim();
+        }
+        return cleaned;
+    }
+
+    private static String renderPathSvg(List<String> nodes) {
+        int width = 960;
+        int headerHeight = 24;
+        int rowHeight = 50;
+        int height = Math.max(140, headerHeight + (nodes.size() * rowHeight) + 30);
+
+        StringBuilder svg = new StringBuilder(1024);
+        svg.append("<svg xmlns='http://www.w3.org/2000/svg' width='").append(width).append("' height='").append(height).append("' viewBox='0 0 ")
+            .append(width).append(' ').append(height).append("'>")
+            .append("<rect width='100%' height='100%' fill='#ffffff'/>")
+            .append("<defs><marker id='arrow' markerWidth='10' markerHeight='8' refX='9' refY='4' orient='auto'>")
+            .append("<polygon points='0 0, 10 4, 0 8' fill='#475467'/></marker></defs>");
+
+        int x = 24;
+        int y = 20;
+        int boxWidth = width - 48;
+        int boxHeight = 30;
+        for (int i = 0; i < nodes.size(); i++) {
+            svg.append("<rect x='").append(x).append("' y='").append(y).append("' width='").append(boxWidth).append("' height='").append(boxHeight)
+                .append("' rx='6' ry='6' fill='#f8f9fb' stroke='#d0d5dd'/>")
+                .append("<text x='").append(x + 10).append("' y='").append(y + 20)
+                .append("' font-family='ui-monospace, SFMono-Regular, Menlo, monospace' font-size='12' fill='#101828'>")
+                .append(escapeSvg(nodes.get(i))).append("</text>");
+
+            if (i < nodes.size() - 1) {
+                int lineY1 = y + boxHeight;
+                int lineY2 = y + rowHeight - 6;
+                int lineX = x + (boxWidth / 2);
+                svg.append("<line x1='").append(lineX).append("' y1='").append(lineY1).append("' x2='").append(lineX).append("' y2='").append(lineY2)
+                    .append("' stroke='#475467' stroke-width='1.5' marker-end='url(#arrow)'/>");
+            }
+            y += rowHeight;
+        }
+        svg.append("</svg>");
+        return svg.toString();
+    }
+
+    private static String escapeSvg(String value) {
+        return escape(value);
+    }
+
+    private static String formatDetails(String message, @Nullable String disabledReason) {
+        if (disabledReason == null || disabledReason.isBlank()) {
+            return message;
+        }
+        return message + " | Disabled: " + disabledReason;
+    }
+
+    private static String renderDetailsCell(DependencyInjectionError error) {
+        String details = formatDetails(error.message(), error.disabledReason());
+        int disabledIndex = details.indexOf(". Disabled candidate beans:");
+
+        if (disabledIndex < 0 && details.length() < 220) {
+            return "<td class='mn-wrap'>" + escape(details) + HTML_TD_CLOSE;
+        }
+
+        String summary = details;
+        String expanded = "";
+        if (disabledIndex > -1) {
+            summary = details.substring(0, disabledIndex + 1).trim();
+            expanded = details.substring(disabledIndex + ". Disabled candidate beans:".length()).trim();
+        } else if (details.length() >= 220) {
+            int split = details.indexOf('.', Math.min(120, details.length() - 1));
+            if (split > -1 && split + 1 < details.length()) {
+                summary = details.substring(0, split + 1).trim();
+                expanded = details.substring(split + 1).trim();
+            }
+        }
+
+        LinkedHashSet<String> bullets = new LinkedHashSet<>();
+        if (!expanded.isBlank()) {
+            for (String part : expanded.split(";\\s+")) {
+                String item = part.trim();
+                if (!item.isBlank()) {
+                    bullets.add(item);
+                }
+            }
+        }
+
+        if (bullets.isEmpty()) {
+            return "<td class='mn-wrap'>" + escape(details) + HTML_TD_CLOSE;
+        }
+
+        StringBuilder out = new StringBuilder(256);
+        out.append("<td class='mn-wrap'>")
+            .append("<div class='mn-detail-main'>")
+            .append(escape(summary))
+            .append("</div>")
+            .append("<details>")
+            .append("<summary>More details</summary>")
+            .append("<ul class='mn-detail-list'>");
+        for (String bullet : bullets) {
+            out.append("<li>").append(escape(bullet)).append("</li>");
+        }
+        out.append("</ul></details></td>");
+        return out.toString();
     }
 
     private static String escape(@Nullable String s) {
@@ -176,4 +387,5 @@ public final class HtmlConfigurationErrorReporter implements ConfigurationErrorR
             .replace("\"", "&quot;")
             .replace("'", "&#39;");
     }
+
 }

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/JsonConfigurationErrorReporter.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/JsonConfigurationErrorReporter.java
@@ -16,7 +16,9 @@
 package io.micronaut.jsonschema.configuration.validator.report;
 
 import io.micronaut.json.JsonMapper;
+import io.micronaut.core.naming.NameUtils;
 import io.micronaut.jsonschema.configuration.validator.ConfigurationError;
+import io.micronaut.jsonschema.configuration.validator.DependencyInjectionError;
 import io.micronaut.serde.annotation.Serdeable;
 
 import java.io.IOException;
@@ -43,7 +45,7 @@ public final class JsonConfigurationErrorReporter implements ConfigurationErrorR
     }
 
     @Override
-    public void report(Set<ConfigurationError> errors) throws IOException {
+    public void report(Set<ConfigurationError> errors, Set<DependencyInjectionError> dependencyInjectionErrors) throws IOException {
         List<JsonConfigurationError> view = new ArrayList<>(errors.size());
         for (ConfigurationError error : errors) {
             view.add(new JsonConfigurationError(
@@ -56,10 +58,28 @@ public final class JsonConfigurationErrorReporter implements ConfigurationErrorR
                 error.lineNumber()
             ));
         }
-        String json = jsonMapper.writeValueAsString(view);
+        List<JsonDependencyInjectionError> diView = new ArrayList<>(dependencyInjectionErrors.size());
+        for (DependencyInjectionError error : dependencyInjectionErrors) {
+            diView.add(new JsonDependencyInjectionError(
+                error.injectionPoint(),
+                shortName(error.bean()),
+                formatDetails(error.message(), error.disabledReason()),
+                error.failingPath(),
+                error.snippet(),
+                error.snippetLanguage()
+            ));
+        }
+        String json = jsonMapper.writeValueAsString(new JsonReport(view, diView));
         output.write(json.getBytes(StandardCharsets.UTF_8));
         output.write('\n');
         output.flush();
+    }
+
+    @Serdeable
+    private record JsonReport(
+        List<JsonConfigurationError> configurationErrors,
+        List<JsonDependencyInjectionError> dependencyInjectionErrors
+    ) {
     }
 
     @Serdeable
@@ -72,5 +92,27 @@ public final class JsonConfigurationErrorReporter implements ConfigurationErrorR
         Object rawValue,
         int lineNumber
     ) {
+    }
+
+    @Serdeable
+    private record JsonDependencyInjectionError(
+        String injectionPoint,
+        String bean,
+        String details,
+        List<String> failingPath,
+        String snippet,
+        String snippetLanguage
+    ) {
+    }
+
+    private static String shortName(String typeName) {
+        return typeName == null ? "" : NameUtils.getShortenedName(typeName);
+    }
+
+    private static String formatDetails(String message, String disabledReason) {
+        if (disabledReason == null || disabledReason.isBlank()) {
+            return message;
+        }
+        return message + " | Disabled: " + disabledReason;
     }
 }

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/JsonConfigurationErrorReporter.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/JsonConfigurationErrorReporter.java
@@ -75,6 +75,17 @@ public final class JsonConfigurationErrorReporter implements ConfigurationErrorR
         output.flush();
     }
 
+    private static String shortName(String typeName) {
+        return typeName == null ? "" : NameUtils.getShortenedName(typeName);
+    }
+
+    private static String formatDetails(String message, String disabledReason) {
+        if (disabledReason == null || disabledReason.isBlank()) {
+            return message;
+        }
+        return message + " | Disabled: " + disabledReason;
+    }
+
     @Serdeable
     private record JsonReport(
         List<JsonConfigurationError> configurationErrors,
@@ -103,16 +114,5 @@ public final class JsonConfigurationErrorReporter implements ConfigurationErrorR
         String snippet,
         String snippetLanguage
     ) {
-    }
-
-    private static String shortName(String typeName) {
-        return typeName == null ? "" : NameUtils.getShortenedName(typeName);
-    }
-
-    private static String formatDetails(String message, String disabledReason) {
-        if (disabledReason == null || disabledReason.isBlank()) {
-            return message;
-        }
-        return message + " | Disabled: " + disabledReason;
     }
 }

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/JsonConfigurationErrorReporter.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/JsonConfigurationErrorReporter.java
@@ -20,6 +20,7 @@ import io.micronaut.core.naming.NameUtils;
 import io.micronaut.jsonschema.configuration.validator.ConfigurationError;
 import io.micronaut.jsonschema.configuration.validator.DependencyInjectionError;
 import io.micronaut.serde.annotation.Serdeable;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -75,11 +76,11 @@ public final class JsonConfigurationErrorReporter implements ConfigurationErrorR
         output.flush();
     }
 
-    private static String shortName(String typeName) {
+    private static String shortName(@Nullable String typeName) {
         return typeName == null ? "" : NameUtils.getShortenedName(typeName);
     }
 
-    private static String formatDetails(String message, String disabledReason) {
+    private static String formatDetails(String message, @Nullable String disabledReason) {
         if (disabledReason == null || disabledReason.isBlank()) {
             return message;
         }

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/SystemErrConfigurationErrorReporter.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/SystemErrConfigurationErrorReporter.java
@@ -154,7 +154,10 @@ public final class SystemErrConfigurationErrorReporter implements ConfigurationE
 
         writer.println(style(useAnsi, Ansi.BOLD) + "Dependency Injection Errors" + style(useAnsi, Ansi.RESET));
         List<DependencyInjectionError> ordered = errors.stream()
-            .sorted(Comparator.comparing(DependencyInjectionError::injectionPoint).thenComparing(DependencyInjectionError::bean))
+            .sorted(Comparator.comparing(
+                DependencyInjectionError::injectionPoint,
+                Comparator.nullsLast(Comparator.naturalOrder())
+            ).thenComparing(DependencyInjectionError::bean))
             .toList();
 
         List<DependencyRow> rows = new ArrayList<>(ordered.size());

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/SystemErrConfigurationErrorReporter.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/SystemErrConfigurationErrorReporter.java
@@ -213,11 +213,15 @@ public final class SystemErrConfigurationErrorReporter implements ConfigurationE
 
     private static List<String> normalizedPathNodes(DependencyInjectionError error) {
         if (error.failingPath().isEmpty()) {
-            return List.of(error.rootBean(), error.bean() + " (failed)");
+            return List.of(error.bean() + " (failed)");
         }
         List<String> nodes = new ArrayList<>(error.failingPath().size());
         for (String pathEntry : error.failingPath()) {
             nodes.add(cleanPathNode(pathEntry));
+        }
+        // Skip the first node if it duplicates the already-printed root
+        if (!nodes.isEmpty() && nodes.get(0).equals(error.rootBean())) {
+            nodes.remove(0);
         }
         return nodes;
     }

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/SystemErrConfigurationErrorReporter.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/SystemErrConfigurationErrorReporter.java
@@ -174,7 +174,7 @@ public final class SystemErrConfigurationErrorReporter implements ConfigurationE
         table.print(writer, useAnsi);
     }
 
-    private static String shortName(String typeName) {
+    private static String shortName(@Nullable String typeName) {
         return typeName == null ? "" : NameUtils.getShortenedName(typeName);
     }
 
@@ -219,7 +219,7 @@ public final class SystemErrConfigurationErrorReporter implements ConfigurationE
         return nodes;
     }
 
-    private static String cleanPathNode(String pathEntry) {
+    private static String cleanPathNode(@Nullable String pathEntry) {
         if (pathEntry == null) {
             return "";
         }

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/SystemErrConfigurationErrorReporter.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/SystemErrConfigurationErrorReporter.java
@@ -16,6 +16,8 @@
 package io.micronaut.jsonschema.configuration.validator.report;
 
 import io.micronaut.jsonschema.configuration.validator.ConfigurationError;
+import io.micronaut.jsonschema.configuration.validator.DependencyInjectionError;
+import io.micronaut.core.naming.NameUtils;
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
@@ -102,16 +104,20 @@ public final class SystemErrConfigurationErrorReporter implements ConfigurationE
     }
 
     @Override
-    public void report(Set<ConfigurationError> errors) throws IOException {
+    public void report(Set<ConfigurationError> errors, Set<DependencyInjectionError> dependencyInjectionErrors) throws IOException {
         PrintWriter writer = new PrintWriter(err);
         boolean useAnsi = shouldUseAnsi(err);
 
-        if (!errors.isEmpty()) {
-            writer.println(style(useAnsi, Ansi.BOLD) + "Configuration Validation Errors Present" + style(useAnsi, Ansi.RESET));
+        if (!errors.isEmpty() || !dependencyInjectionErrors.isEmpty()) {
+            writer.println(style(useAnsi, Ansi.BOLD) + "Validation Errors Present" + style(useAnsi, Ansi.RESET));
             writer.println();
         }
 
         writeTable(writer, errors, useAnsi);
+        writer.println();
+        writeDependencyInjectionTable(writer, dependencyInjectionErrors, useAnsi);
+        writer.println();
+        writeDependencyInjectionGraph(writer, dependencyInjectionErrors);
         writer.println();
         printReportLocationIfPresent(writer, useAnsi);
         writer.flush();
@@ -138,6 +144,90 @@ public final class SystemErrConfigurationErrorReporter implements ConfigurationE
             List.of(60, 8, 80, 40, 40)
         );
         table.print(writer, useAnsi);
+    }
+
+    private static void writeDependencyInjectionTable(PrintWriter writer, Set<DependencyInjectionError> errors, boolean useAnsi) {
+        if (errors.isEmpty()) {
+            writer.println("No dependency injection validation errors.");
+            return;
+        }
+
+        writer.println(style(useAnsi, Ansi.BOLD) + "Dependency Injection Errors" + style(useAnsi, Ansi.RESET));
+        List<DependencyInjectionError> ordered = errors.stream()
+            .sorted(Comparator.comparing(DependencyInjectionError::injectionPoint).thenComparing(DependencyInjectionError::bean))
+            .toList();
+
+        List<DependencyRow> rows = new ArrayList<>(ordered.size());
+        for (DependencyInjectionError error : ordered) {
+            rows.add(new DependencyRow(
+                sanitize(error.injectionPoint()),
+                sanitize(shortName(error.bean())),
+                sanitize(formatDetails(error.message(), error.disabledReason()))
+            ));
+        }
+
+        DependencyTable table = DependencyTable.of(
+            List.of("Injection Point", "Bean", "Details"),
+            rows,
+            List.of(50, 40, 120)
+        );
+        table.print(writer, useAnsi);
+    }
+
+    private static String shortName(String typeName) {
+        return typeName == null ? "" : NameUtils.getShortenedName(typeName);
+    }
+
+    private static String formatDetails(String message, @Nullable String disabledReason) {
+        if (disabledReason == null || disabledReason.isBlank()) {
+            return message;
+        }
+        return message + " | Disabled: " + disabledReason;
+    }
+
+    private static void writeDependencyInjectionGraph(PrintWriter writer, Set<DependencyInjectionError> errors) {
+        if (errors.isEmpty()) {
+            return;
+        }
+        writer.println("Dependency Injection Failure Paths:");
+        List<DependencyInjectionError> ordered = errors.stream()
+            .sorted(Comparator.comparing(DependencyInjectionError::rootBean).thenComparing(DependencyInjectionError::bean))
+            .toList();
+        for (DependencyInjectionError error : ordered) {
+            writer.println("- root: " + error.rootBean());
+            List<String> nodes = normalizedPathNodes(error);
+            if (nodes.isEmpty()) {
+                writer.println("  +--> " + error.bean() + " (failed)");
+                continue;
+            }
+            writer.println("  +--> " + sanitize(nodes.get(0)));
+            for (int i = 1; i < nodes.size(); i++) {
+                writer.println("  |    |");
+                writer.println("  |    +--> " + sanitize(nodes.get(i)));
+            }
+        }
+    }
+
+    private static List<String> normalizedPathNodes(DependencyInjectionError error) {
+        if (error.failingPath().isEmpty()) {
+            return List.of(error.rootBean(), error.bean() + " (failed)");
+        }
+        List<String> nodes = new ArrayList<>(error.failingPath().size());
+        for (String pathEntry : error.failingPath()) {
+            nodes.add(cleanPathNode(pathEntry));
+        }
+        return nodes;
+    }
+
+    private static String cleanPathNode(String pathEntry) {
+        if (pathEntry == null) {
+            return "";
+        }
+        String cleaned = pathEntry.trim();
+        if (cleaned.startsWith("*")) {
+            cleaned = cleaned.substring(1).trim();
+        }
+        return cleaned;
     }
 
     private Row toRow(ConfigurationError error) {
@@ -289,6 +379,9 @@ public final class SystemErrConfigurationErrorReporter implements ConfigurationE
     private record Row(String property, String type, String message, String origin, String value) {
     }
 
+    private record DependencyRow(String injectionPoint, String bean, String details) {
+    }
+
     private static final class Table {
         private final List<String> headers;
         private final List<Row> rows;
@@ -393,6 +486,57 @@ public final class SystemErrConfigurationErrorReporter implements ConfigurationE
                 return s.substring(0, width);
             }
             return s.substring(0, width - 3) + "...";
+        }
+    }
+
+    private static final class DependencyTable {
+        private final List<String> headers;
+        private final List<DependencyRow> rows;
+        private final List<Integer> maxWidths;
+
+        private DependencyTable(List<String> headers, List<DependencyRow> rows, List<Integer> maxWidths) {
+            this.headers = headers;
+            this.rows = rows;
+            this.maxWidths = maxWidths;
+        }
+
+        static DependencyTable of(List<String> headers, List<DependencyRow> rows, List<Integer> maxWidths) {
+            return new DependencyTable(headers, rows, maxWidths);
+        }
+
+        void print(PrintWriter writer, boolean useAnsi) {
+            int wInjectionPoint = Table.computeWidth(headers.get(0), rows.stream().map(DependencyRow::injectionPoint).toList(), maxWidths.get(0));
+            int wBean = Table.computeWidth(headers.get(1), rows.stream().map(DependencyRow::bean).toList(), maxWidths.get(1));
+            int wDetails = Table.computeWidth(headers.get(2), rows.stream().map(DependencyRow::details).toList(), maxWidths.get(2));
+
+            String sep = border(wInjectionPoint, wBean, wDetails);
+            writer.println(sep);
+            writer.println(rowLine(
+                style(useAnsi, Ansi.BOLD) + Table.pad(headers.get(0), wInjectionPoint) + style(useAnsi, Ansi.RESET),
+                style(useAnsi, Ansi.BOLD) + Table.pad(headers.get(1), wBean) + style(useAnsi, Ansi.RESET),
+                style(useAnsi, Ansi.BOLD) + Table.pad(headers.get(2), wDetails) + style(useAnsi, Ansi.RESET)
+            ));
+            writer.println(sep);
+
+            for (DependencyRow r : rows) {
+                writer.println(rowLine(
+                    Table.pad(Table.truncate(r.injectionPoint(), wInjectionPoint), wInjectionPoint),
+                    Table.pad(Table.truncate(r.bean(), wBean), wBean),
+                    Table.pad(Table.truncate(r.details(), wDetails), wDetails)
+                ));
+            }
+            writer.println(sep);
+        }
+
+        private static String border(int wInjectionPoint, int wBean, int wDetails) {
+            return "+" + "-".repeat(wInjectionPoint + 2)
+                + "+" + "-".repeat(wBean + 2)
+                + "+" + "-".repeat(wDetails + 2)
+                + "+";
+        }
+
+        private static String rowLine(String injectionPoint, String bean, String details) {
+            return "| " + injectionPoint + " | " + bean + " | " + details + " |";
         }
     }
 }

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/SystemErrConfigurationErrorReporter.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/report/SystemErrConfigurationErrorReporter.java
@@ -141,7 +141,7 @@ public final class SystemErrConfigurationErrorReporter implements ConfigurationE
         Table table = Table.of(
             List.of("Property", "Type", "Message", "Origin", "Value"),
             rows,
-            List.of(60, 8, 80, 40, 40)
+            List.of(60, 8, 80, Integer.MAX_VALUE, 40)
         );
         table.print(writer, useAnsi);
     }

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionValidatorTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionValidatorTest.java
@@ -285,6 +285,20 @@ class DependencyInjectionValidatorTest {
             ), () -> "Did not expect non-unique candidate error when only one non-secondary bean exists, got: " + errors);
     }
 
+    @Test
+    void factoryMethodMissingBeanDependencyIsReported() {
+        Set<DependencyInjectionError> errors = validate("factory-method-missing-arg", Map.of());
+        assertTrue(errors.stream().anyMatch(e ->
+                e.rootBean().contains("FixtureFactoryMethodMissingArgConsumer")
+                    && e.bean().contains("java.lang.String")
+                    && e.message().contains("No bean of type [java.lang.String] exists")
+                    && e.injectionPoint() != null
+                    && e.injectionPoint().contains("method FixtureFactoryMethodMissingArgFactory.greeter(str)")
+                    && e.snippet() != null
+                    && e.snippet().contains("FixtureFactoryMethodMissingArgFactory.greeter")
+            ), () -> "Expected missing String bean dependency from @Factory method argument to be reported, got: " + errors);
+    }
+
     private static void assertHasError(Set<DependencyInjectionError> errors, String root, String bean, String injectionPoint) {
         assertTrue(errors.stream().anyMatch(e ->
                 e.rootBean().contains(root)
@@ -333,6 +347,7 @@ class DependencyInjectionValidatorTest {
             case "non-unique-primary" -> FixtureMultipleCandidatePrimaryConsumer.class;
             case "non-unique-order" -> FixtureMultipleCandidateOrderConsumer.class;
             case "non-unique-secondary" -> FixtureMultipleCandidateSecondaryConsumer.class;
+            case "factory-method-missing-arg" -> FixtureFactoryMethodMissingArgConsumer.class;
             default -> null;
         };
         if (expected != null) {

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionValidatorTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionValidatorTest.java
@@ -45,6 +45,29 @@ class DependencyInjectionValidatorTest {
     }
 
     @Test
+    void propertyInjectionFailureIsReported() {
+        Set<DependencyInjectionError> errors = validate("property", Map.of());
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.stream().anyMatch(e ->
+                e.rootBean().contains("FixturePropertyInjectionBean")
+                    && e.injectionPoint() != null
+                    && e.injectionPoint().contains("field FixturePropertyInjectionBean.value")
+                    && e.message().contains("Missing required property [spec.missing.property] for @Property injection")
+            ), () -> "Expected missing @Property value error, got: " + errors);
+    }
+
+    @Test
+    void configurationPropertiesConstructorArgumentsAreNotReportedAsDiFailures() {
+        Set<DependencyInjectionError> errors = validate("configuration-properties-record", Map.of());
+        assertFalse(errors.stream().anyMatch(e ->
+                e.bean().contains("java.lang.Boolean")
+                    && e.injectionPoint() != null
+                    && (e.injectionPoint().contains("constructor FixtureConfigurationPropertiesRecord(")
+                    || e.injectionPoint().contains("constructor ReactorConfiguration("))
+            ), () -> "Did not expect missing Boolean DI failures for @ConfigurationProperties constructor args, got: " + errors);
+    }
+
+    @Test
     void constructorInjectionFailureIsReported() {
         Set<DependencyInjectionError> errors = validate("constructor", Map.of());
         assertFalse(errors.isEmpty());
@@ -373,6 +396,8 @@ class DependencyInjectionValidatorTest {
         Class<?> expected = switch (name) {
             case "field" -> FixtureFieldInjectionBean.class;
             case "value" -> FixtureValueInjectionBean.class;
+            case "property" -> FixturePropertyInjectionBean.class;
+            case "configuration-properties-record" -> FixtureConfigurationPropertiesConsumer.class;
             case "constructor" -> FixtureConstructorInjectionBean.class;
             case "method" -> FixtureMethodInjectionBean.class;
             case "eachbean" -> FixtureEachBeanTarget.class;

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionValidatorTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionValidatorTest.java
@@ -12,6 +12,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -65,6 +66,18 @@ class DependencyInjectionValidatorTest {
                     && (e.injectionPoint().contains("constructor FixtureConfigurationPropertiesRecord(")
                     || e.injectionPoint().contains("constructor ReactorConfiguration("))
             ), () -> "Did not expect missing Boolean DI failures for @ConfigurationProperties constructor args, got: " + errors);
+    }
+
+    @Test
+    void validatorClassSuppressionSkipsMatchingRootsAndDependencies() {
+        Set<DependencyInjectionError> errors = validate(
+            "context",
+            Map.of(),
+            new DefaultDependencyInjectionValidator(List.of("io.micronaut.jsonschema.configuration.validator.FixtureContextBean"))
+        );
+        assertFalse(errors.isEmpty(), () -> "Expected other fixture DI errors to still be present, got: " + errors);
+        assertFalse(errors.stream().anyMatch(e -> e.rootBean().contains("FixtureContextBean")),
+            () -> "Expected FixtureContextBean root to be suppressed in validator, got: " + errors);
     }
 
     @Test
@@ -378,6 +391,14 @@ class DependencyInjectionValidatorTest {
     }
 
     private Set<DependencyInjectionError> validate(String name, Map<String, Object> additionalProperties) {
+        return validate(name, additionalProperties, validator);
+    }
+
+    private Set<DependencyInjectionError> validate(
+        String name,
+        Map<String, Object> additionalProperties,
+        DependencyInjectionValidator validationDelegate
+    ) {
         Map<String, Object> properties = new LinkedHashMap<>(additionalProperties.size() + 1);
         properties.put("spec.name", name);
         properties.put("spec.di.validator.test", "true");
@@ -388,7 +409,7 @@ class DependencyInjectionValidatorTest {
             context.getEnvironment().start();
             context.configure();
             assertExpectedFixtureLoaded(context, name);
-            return validator.validate(context);
+            return validationDelegate.validate(context);
         }
     }
 

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionValidatorTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionValidatorTest.java
@@ -501,7 +501,6 @@ class DependencyInjectionValidatorTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private static BeanDefinition<?> beanDefinitionProxy(Optional<Class<?>> declaringType, Class<?> beanType, String beanDescription) {
         InvocationHandler handler = (proxy, method, args) -> switch (method.getName()) {
             case "getDeclaringType" -> declaringType;
@@ -516,7 +515,6 @@ class DependencyInjectionValidatorTest {
         );
     }
 
-    @SuppressWarnings("unchecked")
     private static ConstructorInjectionPoint<?> constructorProxy() {
         InvocationHandler handler = (proxy, method, args) -> defaultValue(method.getReturnType());
         return (ConstructorInjectionPoint<?>) Proxy.newProxyInstance(
@@ -526,7 +524,6 @@ class DependencyInjectionValidatorTest {
         );
     }
 
-    @SuppressWarnings("unchecked")
     private static ConstructorInjectionPoint<?> fieldConstructorProxy(String fieldName) {
         BeanDefinition<?> declaringBean = beanDefinitionProxy(Optional.empty(), DeclaringFixture.class, "DeclaringFixture");
         InvocationHandler handler = (proxy, method, args) -> {

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionValidatorTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionValidatorTest.java
@@ -1,0 +1,335 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.ConfigurableApplicationContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DependencyInjectionValidatorTest {
+
+    private final DependencyInjectionValidator validator = new DefaultDependencyInjectionValidator();
+
+    @Test
+    void fieldInjectionFailureIsReported() {
+        Set<DependencyInjectionError> errors = validate("field", Map.of());
+        assertFalse(errors.isEmpty());
+        assertHasError(errors, "FixtureFieldInjectionBean", "FixtureMissingDependency", "field FixtureFieldInjectionBean.missingDependency");
+    }
+
+    @Test
+    void valueInjectionFailureIsReported() {
+        Set<DependencyInjectionError> errors = validate("value", Map.of());
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.stream().anyMatch(e ->
+                e.rootBean().contains("FixtureValueInjectionBean")
+                    && e.injectionPoint() != null
+                    && e.injectionPoint().contains("field FixtureValueInjectionBean.value")
+                    && e.message().contains("spec.missing.value")
+            ), () -> "Expected missing @Value property error, got: " + errors);
+    }
+
+    @Test
+    void constructorInjectionFailureIsReported() {
+        Set<DependencyInjectionError> errors = validate("constructor", Map.of());
+        assertFalse(errors.isEmpty());
+        assertHasError(errors, "FixtureConstructorInjectionBean", "FixtureMissingDependency", "constructor FixtureConstructorInjectionBean(missingDependency)");
+    }
+
+    @Test
+    void methodInjectionFailureIsReported() {
+        Set<DependencyInjectionError> errors = validate("method", Map.of());
+        assertFalse(errors.isEmpty());
+        assertHasError(errors, "FixtureMethodInjectionBean", "FixtureMissingDependency", "method FixtureMethodInjectionBean.inject(missingDependency)");
+    }
+
+    @Test
+    void eachBeanFailureIsReported() {
+        Set<DependencyInjectionError> errors = validate("eachbean", Map.of("spec.each.one.enabled", "true"));
+        assertFalse(errors.isEmpty());
+        assertHasError(errors, "FixtureEachBeanTarget", "FixtureMissingDependency", "constructor FixtureEachBeanTarget(missingDependency)");
+    }
+
+    @Test
+    void scheduledFailureIsReported() {
+        Set<DependencyInjectionError> errors = validate("scheduled", Map.of());
+        assertFalse(errors.isEmpty());
+        assertHasError(errors, "FixtureScheduledBean", "FixtureMissingDependency", "field FixtureScheduledBean.missingDependency");
+    }
+
+    @Test
+    void controllerFailureIsReported() {
+        Set<DependencyInjectionError> errors = validate("controller", Map.of());
+        assertFalse(errors.isEmpty());
+        assertHasError(errors, "FixtureControllerBean", "FixtureMissingDependency", "constructor FixtureControllerBean(missingDependency)");
+    }
+
+    @Test
+    void contextFailureIsReported() {
+        Set<DependencyInjectionError> errors = validate("context", Map.of());
+        assertFalse(errors.isEmpty());
+        assertHasError(errors, "FixtureContextBean", "FixtureMissingDependency", "constructor FixtureContextBean(missingDependency)");
+    }
+
+    @Test
+    void startupListenerFailureIsReported() {
+        Set<DependencyInjectionError> errors = validate("startup-listener", Map.of());
+        assertFalse(errors.isEmpty());
+        assertHasError(errors, "FixtureStartupListenerBean", "FixtureMissingDependency", "constructor FixtureStartupListenerBean(missingDependency)");
+    }
+
+    @Test
+    void eachBeanPrimaryInjectionReportsMissingConfigurationKey() {
+        Set<DependencyInjectionError> errors = validate("eachbean-primary", Map.of());
+        assertTrue(errors.stream().anyMatch(e ->
+                e.rootBean().contains("FixtureEachBeanPrimaryConsumer")
+                    && e.bean().contains("FixtureDataSource")
+                    && e.message().contains("datasources.default")
+            ), () -> "Expected missing datasources.default message, got: " + errors);
+    }
+
+    @Test
+    void eachBeanPrimaryInjectionSucceedsWhenDefaultConfigured() {
+        Set<DependencyInjectionError> errors = validate("eachbean-primary", Map.of("datasources.default.url", "jdbc:h2:mem:default"));
+        assertFalse(errors.stream().anyMatch(e ->
+            e.rootBean().contains("FixtureEachBeanPrimaryConsumer")
+                && e.bean().contains("FixtureDataSource")
+        ), () -> "Did not expect datasource injection error for configured default datasource, got: " + errors);
+    }
+
+    @Test
+    void eachBeanNamedInjectionReportsMissingConfigurationKey() {
+        Set<DependencyInjectionError> errors = validate("eachbean-named", Map.of());
+        assertTrue(errors.stream().anyMatch(e ->
+                e.rootBean().contains("FixtureEachBeanNamedConsumer")
+                    && e.bean().contains("FixtureDataSource")
+                    && e.message().contains("datasources.other")
+            ), () -> "Expected missing datasources.other message, got: " + errors);
+    }
+
+    @Test
+    void eachBeanNamedInjectionSucceedsWhenNamedConfigured() {
+        Set<DependencyInjectionError> errors = validate("eachbean-named", Map.of("datasources.other.url", "jdbc:h2:mem:other"));
+        assertFalse(errors.stream().anyMatch(e ->
+            e.rootBean().contains("FixtureEachBeanNamedConsumer")
+                && e.bean().contains("FixtureDataSource")
+        ), () -> "Did not expect datasource injection error for configured named datasource, got: " + errors);
+    }
+
+    @Test
+    void eachBeanPrimaryInjectionSucceedsWhenAnyNestedPropertyConfigured() {
+        Set<DependencyInjectionError> errors = validate("eachbean-primary", Map.of("datasources.default.username", "sa"));
+        assertFalse(errors.stream().anyMatch(e ->
+            e.rootBean().contains("FixtureEachBeanPrimaryConsumer")
+                && e.bean().contains("FixtureDataSource")
+        ), () -> "Did not expect datasource injection error when datasources.default prefix is present, got: " + errors);
+    }
+
+    @Test
+    void eachBeanNamedInjectionSucceedsWhenAnyNestedPropertyConfigured() {
+        Set<DependencyInjectionError> errors = validate("eachbean-named", Map.of("datasources.other.username", "sa"));
+        assertFalse(errors.stream().anyMatch(e ->
+            e.rootBean().contains("FixtureEachBeanNamedConsumer")
+                && e.bean().contains("FixtureDataSource")
+        ), () -> "Did not expect datasource injection error when datasources.other prefix is present, got: " + errors);
+    }
+
+    @Test
+    void eachBeanChainPrimaryInjectionReportsMissingConfigurationPrefix() {
+        Set<DependencyInjectionError> errors = validate("eachbean-chain-primary", Map.of());
+        assertTrue(errors.stream().anyMatch(e ->
+                e.rootBean().contains("FixtureEachBeanChainPrimaryConsumer")
+                    && e.bean().contains("FixtureDataSourceConfigurer")
+                    && e.message().contains("datasources.default")
+            ), () -> "Expected missing datasources.default message for each-bean chain, got: " + errors);
+    }
+
+    @Test
+    void eachBeanChainPrimaryInjectionSucceedsWhenPrefixConfigured() {
+        Set<DependencyInjectionError> errors = validate("eachbean-chain-primary", Map.of("datasources.default.username", "sa"));
+        assertFalse(errors.stream().anyMatch(e ->
+            e.rootBean().contains("FixtureEachBeanChainPrimaryConsumer")
+                && e.bean().contains("FixtureDataSourceConfigurer")
+        ), () -> "Did not expect each-bean chain injection error when datasources.default prefix is present, got: " + errors);
+    }
+
+    @Test
+    void eachBeanChainNamedInjectionReportsMissingConfigurationPrefix() {
+        Set<DependencyInjectionError> errors = validate("eachbean-chain-named", Map.of());
+        assertTrue(errors.stream().anyMatch(e ->
+                e.rootBean().contains("FixtureEachBeanChainNamedConsumer")
+                    && e.bean().contains("FixtureDataSourceConfigurer")
+                    && e.message().contains("datasources.other")
+            ), () -> "Expected missing datasources.other message for each-bean chain, got: " + errors);
+    }
+
+    @Test
+    void eachBeanChainNamedInjectionSucceedsWhenPrefixConfigured() {
+        Set<DependencyInjectionError> errors = validate("eachbean-chain-named", Map.of("datasources.other.username", "sa"));
+        assertFalse(errors.stream().anyMatch(e ->
+            e.rootBean().contains("FixtureEachBeanChainNamedConsumer")
+                && e.bean().contains("FixtureDataSourceConfigurer")
+        ), () -> "Did not expect each-bean chain injection error when datasources.other prefix is present, got: " + errors);
+    }
+
+    @Test
+    void circularDependencyFailureIsReported() {
+        Set<DependencyInjectionError> errors = validate("circular", Map.of());
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.stream().anyMatch(e ->
+            e.message().contains("Circular dependency detected")
+                && e.injectionPoint() != null
+                && e.injectionPoint().contains("constructor FixtureCircularBeanB(beanA)")
+                && e.failingPath().stream().anyMatch(p -> p.contains("FixtureCircularBeanA"))
+                && e.failingPath().stream().anyMatch(p -> p.contains("FixtureCircularBeanB"))
+        ), () -> "Expected circular dependency error A->B->A, got: " + errors);
+    }
+
+    @Test
+    void conditionalBeanRequirementDisablementIsReported() {
+        Set<DependencyInjectionError> errors = validate("conditional-single", Map.of());
+        assertTrue(errors.stream().anyMatch(e ->
+                e.rootBean().contains("FixtureConditionalSingleConsumer")
+                    && e.bean().contains("FixtureConditionalService")
+                    && e.message().contains("Disabled candidate beans")
+                    && e.message().contains("FixtureConditionalBeanRequiredCandidate")
+                    && e.message().contains("FixtureConditionalDependency")
+                    && e.disabledReason() != null
+                    && e.disabledReason().contains("FixtureConditionalBeanRequiredCandidate")
+            ), () -> "Expected disabled conditional candidate reason in message and disabledReason, got: " + errors);
+    }
+
+    @Test
+    void multipleDisabledCandidatesAreReportedWithReasons() {
+        Set<DependencyInjectionError> errors = validate("conditional-multi", Map.of());
+        assertTrue(errors.stream().anyMatch(e ->
+                e.rootBean().contains("FixtureConditionalMultiConsumer")
+                    && e.bean().contains("FixtureConditionalService")
+                    && e.message().contains("Disabled candidate beans")
+                    && e.message().contains("FixtureConditionalPropertyRequiredCandidate")
+                    && e.message().contains("FixtureConditionalMultiBeanRequiredCandidate")
+                    && e.message().contains("spec.conditional.enabled")
+                    && e.message().contains("FixtureConditionalDependency")
+                    && e.disabledReason() != null
+                    && e.disabledReason().contains("FixtureConditionalPropertyRequiredCandidate")
+                    && e.disabledReason().contains("FixtureConditionalMultiBeanRequiredCandidate")
+            ), () -> "Expected both disabled candidates and reasons to be reported, got: " + errors);
+    }
+
+    @Test
+    void nestedDependencyFailurePathIsReported() {
+        Set<DependencyInjectionError> errors = validate("nested", Map.of());
+        assertTrue(errors.stream().anyMatch(e ->
+                e.rootBean().contains("FixtureNestedDependencyA")
+                    && e.bean().contains("FixtureMissingDependency")
+                    && e.injectionPoint() != null
+                    && e.injectionPoint().contains("constructor FixtureNestedDependencyB(missingDependency)")
+                    && e.failingPath().stream().anyMatch(p -> p.contains("FixtureNestedDependencyA"))
+                    && e.failingPath().stream().anyMatch(p -> p.contains("FixtureNestedDependencyB"))
+                    && e.failingPath().stream().anyMatch(p -> p.contains("missing io.micronaut.jsonschema.configuration.validator.FixtureMissingDependency"))
+            ), () -> "Expected nested path FixtureNestedDependencyA -> FixtureNestedDependencyB -> missing dependency, got: " + errors);
+    }
+
+    @Test
+    void implicitInfrastructureBeansAreExcludedFromMissingDependencyErrors() {
+        Set<DependencyInjectionError> errors = validate("implicit-infrastructure", Map.of());
+        assertFalse(errors.stream().anyMatch(e ->
+            e.rootBean().contains("FixtureImplicitInfrastructureBean")
+                && (e.bean().contains("io.micronaut.context.env.Environment")
+                || e.bean().contains("io.micronaut.core.value.PropertyResolver"))
+        ), () -> "Did not expect Environment/PropertyResolver to be reported missing, got: " + errors);
+    }
+
+    private static void assertHasError(Set<DependencyInjectionError> errors, String root, String bean, String injectionPoint) {
+        assertTrue(errors.stream().anyMatch(e ->
+                e.rootBean().contains(root)
+                    && e.bean().contains(bean)
+                    && e.injectionPoint() != null
+                    && e.injectionPoint().contains(injectionPoint)
+            ), () -> "Expected error [" + root + ", " + bean + ", " + injectionPoint + "], got: " + errors);
+    }
+
+    private Set<DependencyInjectionError> validate(String name, Map<String, Object> additionalProperties) {
+        Map<String, Object> properties = new LinkedHashMap<>(additionalProperties.size() + 1);
+        properties.put("spec.name", name);
+        properties.put("spec.di.validator.test", "true");
+        properties.put("micronaut.jsonschema.configuration.validator.endpoint.enabled", "false");
+        properties.put("endpoints.enabled", "false");
+        properties.putAll(additionalProperties);
+        try (ConfigurableApplicationContext context = (ConfigurableApplicationContext) ApplicationContext.builder("di-validator-test").properties(properties).build()) {
+            context.getEnvironment().start();
+            context.configure();
+            assertExpectedFixtureLoaded(context, name);
+            return validator.validate(context);
+        }
+    }
+
+    private static void assertExpectedFixtureLoaded(ConfigurableApplicationContext context, String name) {
+        Class<?> expected = switch (name) {
+            case "field" -> FixtureFieldInjectionBean.class;
+            case "value" -> FixtureValueInjectionBean.class;
+            case "constructor" -> FixtureConstructorInjectionBean.class;
+            case "method" -> FixtureMethodInjectionBean.class;
+            case "eachbean" -> FixtureEachBeanTarget.class;
+            case "scheduled" -> FixtureScheduledBean.class;
+            case "controller" -> FixtureControllerBean.class;
+            case "context" -> FixtureContextBean.class;
+            case "startup-listener" -> FixtureStartupListenerBean.class;
+            case "circular" -> FixtureCircularBeanA.class;
+            case "eachbean-primary" -> FixtureEachBeanPrimaryConsumer.class;
+            case "eachbean-named" -> FixtureEachBeanNamedConsumer.class;
+            case "eachbean-chain-primary" -> FixtureEachBeanChainPrimaryConsumer.class;
+            case "eachbean-chain-named" -> FixtureEachBeanChainNamedConsumer.class;
+            case "conditional-single" -> FixtureConditionalSingleConsumer.class;
+            case "conditional-multi" -> FixtureConditionalMultiConsumer.class;
+            case "nested" -> FixtureNestedDependencyA.class;
+            case "implicit-infrastructure" -> FixtureImplicitInfrastructureBean.class;
+            default -> null;
+        };
+        if (expected != null) {
+            String expectedName = expected.getName();
+            boolean foundInDefinitions = context.getAllBeanDefinitions()
+                .stream()
+                .anyMatch(definition -> definition.getBeanType().getName().equals(expectedName));
+            boolean foundInDisabled = context.getDisabledBeans()
+                .stream()
+                .anyMatch(disabledBean -> disabledBean.getName().contains(expectedName));
+            if ("eachbean-primary".equals(name) || "eachbean-named".equals(name)) {
+                assertTrue(foundInDefinitions, () ->
+                    "Expected fixture bean definition to be active (not disabled): " + expectedName
+                        + "\nDefinitions: " + context.getAllBeanDefinitions().stream()
+                        .map(definition -> definition.getBeanType().getName())
+                        .filter(type -> type.contains("Fixture"))
+                        .sorted()
+                        .collect(Collectors.toList())
+                        + "\nDisabled: " + context.getDisabledBeans().stream()
+                        .map(disabledBean -> disabledBean.getName() + " => " + disabledBean.reasons())
+                        .filter(type -> type.contains("Fixture"))
+                        .sorted()
+                        .collect(Collectors.toList())
+                );
+                return;
+            }
+            assertTrue(foundInDefinitions || foundInDisabled, () ->
+                "Expected fixture metadata not loaded: " + expectedName
+                    + "\nDefinitions: " + context.getAllBeanDefinitions().stream()
+                    .map(definition -> definition.getBeanType().getName())
+                    .filter(type -> type.contains("Fixture"))
+                    .sorted()
+                    .collect(Collectors.toList())
+                    + "\nDisabled: " + context.getDisabledBeans().stream()
+                    .map(disabledBean -> disabledBean.getName() + " => " + disabledBean.reasons())
+                    .filter(type -> type.contains("Fixture"))
+                    .sorted()
+                    .collect(Collectors.toList())
+            );
+        }
+    }
+
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionValidatorTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionValidatorTest.java
@@ -246,6 +246,45 @@ class DependencyInjectionValidatorTest {
         ), () -> "Did not expect Environment/PropertyResolver to be reported missing, got: " + errors);
     }
 
+    @Test
+    void nonUniqueCandidatesFailureIsReported() {
+        Set<DependencyInjectionError> errors = validate("non-unique", Map.of());
+        assertTrue(errors.stream().anyMatch(e ->
+                e.rootBean().contains("FixtureMultipleCandidateConsumer")
+                    && e.bean().contains("FixtureMultipleCandidateService")
+                    && e.message().contains("Multiple possible bean candidates found")
+                    && e.message().contains("FixtureMultipleCandidateOne")
+                    && e.message().contains("FixtureMultipleCandidateTwo")
+            ), () -> "Expected non-unique candidate error to be reported, got: " + errors);
+    }
+
+    @Test
+    void primaryCandidateNarrowingResolvesSingleBean() {
+        Set<DependencyInjectionError> errors = validate("non-unique-primary", Map.of());
+        assertFalse(errors.stream().anyMatch(e ->
+                e.rootBean().contains("FixtureMultipleCandidatePrimaryConsumer")
+                    && e.bean().contains("FixtureMultipleCandidateService")
+            ), () -> "Did not expect non-unique candidate error when a primary bean exists, got: " + errors);
+    }
+
+    @Test
+    void orderedCandidateNarrowingResolvesSingleBean() {
+        Set<DependencyInjectionError> errors = validate("non-unique-order", Map.of());
+        assertFalse(errors.stream().anyMatch(e ->
+                e.rootBean().contains("FixtureMultipleCandidateOrderConsumer")
+                    && e.bean().contains("FixtureMultipleCandidateService")
+            ), () -> "Did not expect non-unique candidate error when bean order differs, got: " + errors);
+    }
+
+    @Test
+    void secondaryCandidatesAreIgnoredWhenPrimaryCandidatesExist() {
+        Set<DependencyInjectionError> errors = validate("non-unique-secondary", Map.of());
+        assertFalse(errors.stream().anyMatch(e ->
+                e.rootBean().contains("FixtureMultipleCandidateSecondaryConsumer")
+                    && e.bean().contains("FixtureMultipleCandidateService")
+            ), () -> "Did not expect non-unique candidate error when only one non-secondary bean exists, got: " + errors);
+    }
+
     private static void assertHasError(Set<DependencyInjectionError> errors, String root, String bean, String injectionPoint) {
         assertTrue(errors.stream().anyMatch(e ->
                 e.rootBean().contains(root)
@@ -290,6 +329,10 @@ class DependencyInjectionValidatorTest {
             case "conditional-multi" -> FixtureConditionalMultiConsumer.class;
             case "nested" -> FixtureNestedDependencyA.class;
             case "implicit-infrastructure" -> FixtureImplicitInfrastructureBean.class;
+            case "non-unique" -> FixtureMultipleCandidateConsumer.class;
+            case "non-unique-primary" -> FixtureMultipleCandidatePrimaryConsumer.class;
+            case "non-unique-order" -> FixtureMultipleCandidateOrderConsumer.class;
+            case "non-unique-secondary" -> FixtureMultipleCandidateSecondaryConsumer.class;
             default -> null;
         };
         if (expected != null) {

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionValidatorTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionValidatorTest.java
@@ -2,15 +2,24 @@ package io.micronaut.jsonschema.configuration.validator;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.ConfigurableApplicationContext;
+import io.micronaut.core.type.Argument;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.ConstructorInjectionPoint;
+import io.micronaut.inject.FieldInjectionPoint;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class DependencyInjectionValidatorTest {
 
@@ -299,6 +308,43 @@ class DependencyInjectionValidatorTest {
             ), () -> "Expected missing String bean dependency from @Factory method argument to be reported, got: " + errors);
     }
 
+    @Test
+    void constructorInjectionPointDescriptionUsesFieldInjectionPointWhenPresent() {
+        BeanDefinition<?> definition = beanDefinitionProxy(Optional.of(DeclaringFixture.class), FallbackGreeterFixture.class, "Fixture");
+        ConstructorInjectionPoint<?> fieldInjectionPoint = fieldConstructorProxy("greeter");
+        Argument<?> argument = Argument.of(String.class, "str");
+
+        String description = invokeConstructorInjectionPointDescription(definition, fieldInjectionPoint, argument);
+
+        assertEquals("field DeclaringFixture.greeter", description);
+    }
+
+    @Test
+    void constructorInjectionPointDescriptionUsesFactoryMemberFallback() {
+        BeanDefinition<?> definition = beanDefinitionProxy(
+            Optional.of(FallbackFactoryFixture.class),
+            FallbackGreeterFixture.class,
+            "@j.i.Singleton i.m.m.e.g.FallbackGreeterFixture i.m.m.e.g.FallbackFactoryFixture.greeter"
+        );
+        ConstructorInjectionPoint<?> constructor = constructorProxy();
+        Argument<?> argument = Argument.of(String.class, "str");
+
+        String description = invokeConstructorInjectionPointDescription(definition, constructor, argument);
+
+        assertEquals("method FallbackFactoryFixture.greeter(str)", description);
+    }
+
+    @Test
+    void constructorInjectionPointDescriptionFallsBackToConstructorWhenFactoryMemberCannotBeResolved() {
+        BeanDefinition<?> definition = beanDefinitionProxy(Optional.of(FallbackFactoryFixture.class), FallbackGreeterFixture.class, "FallbackGreeterFixture");
+        ConstructorInjectionPoint<?> constructor = constructorProxy();
+        Argument<?> argument = Argument.of(String.class, "str");
+
+        String description = invokeConstructorInjectionPointDescription(definition, constructor, argument);
+
+        assertEquals("constructor FallbackGreeterFixture(str)", description);
+    }
+
     private static void assertHasError(Set<DependencyInjectionError> errors, String root, String bean, String injectionPoint) {
         assertTrue(errors.stream().anyMatch(e ->
                 e.rootBean().contains(root)
@@ -388,6 +434,106 @@ class DependencyInjectionValidatorTest {
                     .collect(Collectors.toList())
             );
         }
+    }
+
+    private static String invokeConstructorInjectionPointDescription(
+        BeanDefinition<?> definition,
+        ConstructorInjectionPoint<?> constructor,
+        Argument<?> argument
+    ) {
+        try {
+            Method method = DefaultDependencyInjectionValidator.class.getDeclaredMethod(
+                "constructorInjectionPointDescription",
+                BeanDefinition.class,
+                ConstructorInjectionPoint.class,
+                Argument.class
+            );
+            method.setAccessible(true);
+            return (String) method.invoke(null, definition, constructor, argument);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Failed to invoke constructorInjectionPointDescription", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static BeanDefinition<?> beanDefinitionProxy(Optional<Class<?>> declaringType, Class<?> beanType, String beanDescription) {
+        InvocationHandler handler = (proxy, method, args) -> switch (method.getName()) {
+            case "getDeclaringType" -> declaringType;
+            case "getBeanType" -> beanType;
+            case "getBeanDescription" -> beanDescription;
+            default -> defaultValue(method.getReturnType());
+        };
+        return (BeanDefinition<?>) Proxy.newProxyInstance(
+            DependencyInjectionValidatorTest.class.getClassLoader(),
+            new Class<?>[] {BeanDefinition.class},
+            handler
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ConstructorInjectionPoint<?> constructorProxy() {
+        InvocationHandler handler = (proxy, method, args) -> defaultValue(method.getReturnType());
+        return (ConstructorInjectionPoint<?>) Proxy.newProxyInstance(
+            DependencyInjectionValidatorTest.class.getClassLoader(),
+            new Class<?>[] {ConstructorInjectionPoint.class},
+            handler
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ConstructorInjectionPoint<?> fieldConstructorProxy(String fieldName) {
+        BeanDefinition<?> declaringBean = beanDefinitionProxy(Optional.empty(), DeclaringFixture.class, "DeclaringFixture");
+        InvocationHandler handler = (proxy, method, args) -> {
+            if ("getName".equals(method.getName())) {
+                return fieldName;
+            }
+            if ("getDeclaringBean".equals(method.getName())) {
+                return declaringBean;
+            }
+            return defaultValue(method.getReturnType());
+        };
+        return (ConstructorInjectionPoint<?>) Proxy.newProxyInstance(
+            DependencyInjectionValidatorTest.class.getClassLoader(),
+            new Class<?>[] {ConstructorInjectionPoint.class, FieldInjectionPoint.class},
+            handler
+        );
+    }
+
+    private static Object defaultValue(Class<?> returnType) {
+        if (!returnType.isPrimitive()) {
+            return null;
+        }
+        if (returnType == boolean.class) {
+            return false;
+        }
+        if (returnType == char.class) {
+            return '\0';
+        }
+        if (returnType == byte.class) {
+            return (byte) 0;
+        }
+        if (returnType == short.class) {
+            return (short) 0;
+        }
+        if (returnType == int.class) {
+            return 0;
+        }
+        if (returnType == long.class) {
+            return 0L;
+        }
+        if (returnType == float.class) {
+            return 0f;
+        }
+        return 0d;
+    }
+
+    private static final class DeclaringFixture {
+    }
+
+    private static final class FallbackFactoryFixture {
+    }
+
+    private static final class FallbackGreeterFixture {
     }
 
 }

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureCircularBeanA.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureCircularBeanA.java
@@ -1,0 +1,16 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+
+/**
+ * Test fixture bean participating in a constructor-based circular dependency (A -> B).
+ */
+@Context
+@Requires(env = "di-validator-test")
+public final class FixtureCircularBeanA {
+    @Inject
+    FixtureCircularBeanA(FixtureCircularBeanB beanB) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureCircularBeanB.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureCircularBeanB.java
@@ -1,0 +1,16 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+
+/**
+ * Test fixture bean participating in a constructor-based circular dependency (B -> A).
+ */
+@Context
+@Requires(env = "di-validator-test")
+public final class FixtureCircularBeanB {
+    @Inject
+    FixtureCircularBeanB(FixtureCircularBeanA beanA) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureCliDisabledCandidateBean.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureCliDisabledCandidateBean.java
@@ -1,0 +1,10 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(env = "di-validator-test")
+@Requires(bean = FixtureConditionalDependency.class)
+public final class FixtureCliDisabledCandidateBean implements FixtureCliDisabledService {
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureCliDisabledCandidateProperty.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureCliDisabledCandidateProperty.java
@@ -1,0 +1,10 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(env = "di-validator-test")
+@Requires(property = "spec.cli.disabled.enabled", value = "true")
+public final class FixtureCliDisabledCandidateProperty implements FixtureCliDisabledService {
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureCliDisabledConsumer.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureCliDisabledConsumer.java
@@ -1,0 +1,11 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+
+@Context
+@Requires(env = "di-validator-test")
+public final class FixtureCliDisabledConsumer {
+    FixtureCliDisabledConsumer(FixtureCliDisabledService service) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureCliDisabledService.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureCliDisabledService.java
@@ -1,0 +1,4 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+public interface FixtureCliDisabledService {
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureConditionalBeanRequiredCandidate.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureConditionalBeanRequiredCandidate.java
@@ -1,0 +1,11 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(env = "di-validator-test")
+@Requires(property = "spec.name", value = "conditional-single")
+@Requires(bean = FixtureConditionalDependency.class)
+public final class FixtureConditionalBeanRequiredCandidate implements FixtureConditionalService {
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureConditionalDependency.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureConditionalDependency.java
@@ -1,0 +1,4 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+public final class FixtureConditionalDependency {
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureConditionalMultiBeanRequiredCandidate.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureConditionalMultiBeanRequiredCandidate.java
@@ -1,0 +1,11 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(env = "di-validator-test")
+@Requires(property = "spec.name", value = "conditional-multi")
+@Requires(bean = FixtureConditionalDependency.class)
+public final class FixtureConditionalMultiBeanRequiredCandidate implements FixtureConditionalService {
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureConditionalMultiConsumer.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureConditionalMultiConsumer.java
@@ -1,0 +1,12 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+
+@Context
+@Requires(env = "di-validator-test")
+@Requires(property = "spec.name", value = "conditional-multi")
+public final class FixtureConditionalMultiConsumer {
+    FixtureConditionalMultiConsumer(FixtureConditionalService service) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureConditionalPropertyRequiredCandidate.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureConditionalPropertyRequiredCandidate.java
@@ -1,0 +1,11 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(env = "di-validator-test")
+@Requires(property = "spec.name", value = "conditional-multi")
+@Requires(property = "spec.conditional.enabled", value = "true")
+public final class FixtureConditionalPropertyRequiredCandidate implements FixtureConditionalService {
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureConditionalService.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureConditionalService.java
@@ -1,0 +1,4 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+public interface FixtureConditionalService {
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureConditionalSingleConsumer.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureConditionalSingleConsumer.java
@@ -1,0 +1,12 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+
+@Context
+@Requires(env = "di-validator-test")
+@Requires(property = "spec.name", value = "conditional-single")
+public final class FixtureConditionalSingleConsumer {
+    FixtureConditionalSingleConsumer(FixtureConditionalService service) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureConfigurationPropertiesConsumer.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureConfigurationPropertiesConsumer.java
@@ -1,0 +1,12 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+
+@Context
+@Requires(property = "spec.name", value = "configuration-properties-record")
+@Requires(env = "di-validator-test")
+final class FixtureConfigurationPropertiesConsumer {
+    FixtureConfigurationPropertiesConsumer(FixtureConfigurationPropertiesRecord configuration) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureConfigurationPropertiesRecord.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureConfigurationPropertiesRecord.java
@@ -1,0 +1,14 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Nullable;
+
+@ConfigurationProperties("fixture.reactor")
+@Requires(property = "spec.name", value = "configuration-properties-record")
+@Requires(env = "di-validator-test")
+record FixtureConfigurationPropertiesRecord(
+    @Nullable Boolean enableAutomaticContextPropagation,
+    @Nullable Boolean enableScheduleHookContextPropagation
+) {
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureConstructorInjectionBean.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureConstructorInjectionBean.java
@@ -1,0 +1,14 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+
+/**
+ * Test fixture bean that exercises required constructor injection validation.
+ */
+@Context
+@Requires(env = "di-validator-test")
+public final class FixtureConstructorInjectionBean {
+    FixtureConstructorInjectionBean(FixtureMissingDependency missingDependency) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureContextBean.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureContextBean.java
@@ -1,0 +1,14 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+
+/**
+ * Test fixture bean used to validate context bean constructor dependency checks.
+ */
+@Context
+@Requires(env = "di-validator-test")
+public final class FixtureContextBean {
+    FixtureContextBean(FixtureMissingDependency missingDependency) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureControllerBean.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureControllerBean.java
@@ -1,0 +1,20 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+
+/**
+ * Test fixture controller used to validate constructor dependency checks for controller roots.
+ */
+@Controller("/fixture")
+@Requires(env = "di-validator-test")
+public final class FixtureControllerBean {
+    FixtureControllerBean(FixtureMissingDependency missingDependency) {
+    }
+
+    @Get("/")
+    String index() {
+        return "ok";
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureDataSource.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureDataSource.java
@@ -1,0 +1,7 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+/**
+ * Fixture abstraction representing a datasource-like bean produced from {@code @EachBean}.
+ */
+public interface FixtureDataSource {
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureDataSourceBean.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureDataSourceBean.java
@@ -1,0 +1,14 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Requires;
+
+/**
+ * Fixture bean produced per datasource configuration entry.
+ */
+@EachBean(FixtureDataSourceConfiguration.class)
+@Requires(env = "di-validator-test")
+public final class FixtureDataSourceBean implements FixtureDataSource {
+    FixtureDataSourceBean(FixtureDataSourceConfiguration configuration) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureDataSourceConfiguration.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureDataSourceConfiguration.java
@@ -1,0 +1,31 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
+
+/**
+ * Fixture {@code @EachProperty} configuration emulating datasource-style named entries.
+ */
+@EachProperty(value = "datasources", primary = "default")
+@Requires(env = "di-validator-test")
+public final class FixtureDataSourceConfiguration {
+    private final String name;
+    private String url;
+
+    FixtureDataSourceConfiguration(@Parameter String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureDataSourceConfigurer.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureDataSourceConfigurer.java
@@ -1,0 +1,4 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+public interface FixtureDataSourceConfigurer {
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureDataSourceConfigurerBean.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureDataSourceConfigurerBean.java
@@ -1,0 +1,11 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Requires;
+
+@EachBean(FixtureDataSourceBean.class)
+@Requires(env = "di-validator-test")
+public final class FixtureDataSourceConfigurerBean implements FixtureDataSourceConfigurer {
+    FixtureDataSourceConfigurerBean(FixtureDataSourceBean dataSourceBean) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureEachBeanChainNamedConsumer.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureEachBeanChainNamedConsumer.java
@@ -13,6 +13,7 @@ public final class FixtureEachBeanChainNamedConsumer {
     }
 
     @Executable(processOnStartup = true)
+    @SuppressWarnings("java:S1186")
     void entrypoint() {
     }
 }

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureEachBeanChainNamedConsumer.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureEachBeanChainNamedConsumer.java
@@ -1,0 +1,18 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Executable;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(env = "di-validator-test")
+@Requires(property = "spec.name", value = "eachbean-chain-named")
+public final class FixtureEachBeanChainNamedConsumer {
+    FixtureEachBeanChainNamedConsumer(@Named("other") FixtureDataSourceConfigurer configurer) {
+    }
+
+    @Executable(processOnStartup = true)
+    void entrypoint() {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureEachBeanChainPrimaryConsumer.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureEachBeanChainPrimaryConsumer.java
@@ -12,6 +12,7 @@ public final class FixtureEachBeanChainPrimaryConsumer {
     }
 
     @Executable(processOnStartup = true)
+    @SuppressWarnings("java:S1186")
     void entrypoint() {
     }
 }

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureEachBeanChainPrimaryConsumer.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureEachBeanChainPrimaryConsumer.java
@@ -1,0 +1,17 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Executable;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(env = "di-validator-test")
+@Requires(property = "spec.name", value = "eachbean-chain-primary")
+public final class FixtureEachBeanChainPrimaryConsumer {
+    FixtureEachBeanChainPrimaryConsumer(FixtureDataSourceConfigurer configurer) {
+    }
+
+    @Executable(processOnStartup = true)
+    void entrypoint() {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureEachBeanNamedConsumer.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureEachBeanNamedConsumer.java
@@ -1,0 +1,20 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Executable;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+/**
+ * Fixture consumer that injects a named datasource bean produced from each-property config.
+ */
+@Singleton
+@Requires(env = "di-validator-test")
+public final class FixtureEachBeanNamedConsumer {
+    FixtureEachBeanNamedConsumer(@Named("other") FixtureDataSource dataSource) {
+    }
+
+    @Executable(processOnStartup = true)
+    void entrypoint() {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureEachBeanNamedConsumer.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureEachBeanNamedConsumer.java
@@ -15,6 +15,7 @@ public final class FixtureEachBeanNamedConsumer {
     }
 
     @Executable(processOnStartup = true)
+    @SuppressWarnings("java:S1186")
     void entrypoint() {
     }
 }

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureEachBeanPrimaryConsumer.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureEachBeanPrimaryConsumer.java
@@ -1,0 +1,19 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Executable;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+/**
+ * Fixture consumer that injects the primary datasource bean produced from each-property config.
+ */
+@Singleton
+@Requires(env = "di-validator-test")
+public final class FixtureEachBeanPrimaryConsumer {
+    FixtureEachBeanPrimaryConsumer(FixtureDataSource dataSource) {
+    }
+
+    @Executable(processOnStartup = true)
+    void entrypoint() {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureEachBeanPrimaryConsumer.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureEachBeanPrimaryConsumer.java
@@ -14,6 +14,7 @@ public final class FixtureEachBeanPrimaryConsumer {
     }
 
     @Executable(processOnStartup = true)
+    @SuppressWarnings("java:S1186")
     void entrypoint() {
     }
 }

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureEachBeanTarget.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureEachBeanTarget.java
@@ -1,0 +1,16 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Requires;
+
+/**
+ * Test fixture bean created per {@link FixtureEachConfig} entry to validate each-bean injection.
+ */
+@EachBean(FixtureEachConfig.class)
+@Context
+@Requires(env = "di-validator-test")
+public final class FixtureEachBeanTarget {
+    FixtureEachBeanTarget(FixtureMissingDependency missingDependency) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureEachConfig.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureEachConfig.java
@@ -1,0 +1,15 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
+
+/**
+ * Test fixture each-property configuration used as a source bean for {@code @EachBean} tests.
+ */
+@EachProperty("spec.each")
+@Requires(env = "di-validator-test")
+public final class FixtureEachConfig {
+    FixtureEachConfig(@Parameter String name) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureFactoryMethodMissingArgConsumer.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureFactoryMethodMissingArgConsumer.java
@@ -1,0 +1,13 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+
+@Context
+@Requires(property = "spec.name", value = "factory-method-missing-arg")
+@Requires(env = "di-validator-test")
+final class FixtureFactoryMethodMissingArgConsumer {
+
+    FixtureFactoryMethodMissingArgConsumer(FixtureFactoryMethodMissingArgGreeter greeter) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureFactoryMethodMissingArgConsumer.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureFactoryMethodMissingArgConsumer.java
@@ -7,7 +7,9 @@ import io.micronaut.context.annotation.Requires;
 @Requires(property = "spec.name", value = "factory-method-missing-arg")
 @Requires(env = "di-validator-test")
 final class FixtureFactoryMethodMissingArgConsumer {
+    private final FixtureFactoryMethodMissingArgGreeter greeter;
 
     FixtureFactoryMethodMissingArgConsumer(FixtureFactoryMethodMissingArgGreeter greeter) {
+        this.greeter = greeter;
     }
 }

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureFactoryMethodMissingArgFactory.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureFactoryMethodMissingArgFactory.java
@@ -1,0 +1,16 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Factory
+@Requires(property = "spec.name", value = "factory-method-missing-arg")
+@Requires(env = "di-validator-test")
+final class FixtureFactoryMethodMissingArgFactory {
+
+    @Singleton
+    FixtureFactoryMethodMissingArgGreeter greeter(String str) {
+        return new FixtureFactoryMethodMissingArgGreeter();
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureFactoryMethodMissingArgGreeter.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureFactoryMethodMissingArgGreeter.java
@@ -1,0 +1,8 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+final class FixtureFactoryMethodMissingArgGreeter {
+
+    String greet(String name) {
+        return "HELLO " + name;
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureFieldInjectionBean.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureFieldInjectionBean.java
@@ -1,0 +1,15 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+
+/**
+ * Test fixture bean that exercises required field injection validation.
+ */
+@Context
+@Requires(env = "di-validator-test")
+public final class FixtureFieldInjectionBean {
+    @Inject
+    FixtureMissingDependency missingDependency;
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureImplicitInfrastructureBean.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureImplicitInfrastructureBean.java
@@ -1,0 +1,14 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.value.PropertyResolver;
+
+@Context
+@Requires(env = "di-validator-test")
+@Requires(property = "spec.name", value = "implicit-infrastructure")
+public final class FixtureImplicitInfrastructureBean {
+    FixtureImplicitInfrastructureBean(Environment environment, PropertyResolver propertyResolver) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMethodInjectionBean.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMethodInjectionBean.java
@@ -1,0 +1,16 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Inject;
+
+/**
+ * Test fixture bean that exercises required method injection validation.
+ */
+@Context
+@Requires(env = "di-validator-test")
+public final class FixtureMethodInjectionBean {
+    @Inject
+    void inject(FixtureMissingDependency missingDependency) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMethodInjectionBean.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMethodInjectionBean.java
@@ -11,6 +11,7 @@ import jakarta.inject.Inject;
 @Requires(env = "di-validator-test")
 public final class FixtureMethodInjectionBean {
     @Inject
+    @SuppressWarnings("java:S1186")
     void inject(FixtureMissingDependency missingDependency) {
     }
 }

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMissingDependency.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMissingDependency.java
@@ -1,0 +1,7 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+/**
+ * Marker dependency type intentionally left without a bean implementation for validation tests.
+ */
+public final class FixtureMissingDependency {
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidateConsumer.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidateConsumer.java
@@ -1,0 +1,12 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+
+@Context
+@Requires(property = "spec.name", value = "non-unique")
+@Requires(env = "di-validator-test")
+final class FixtureMultipleCandidateConsumer {
+    FixtureMultipleCandidateConsumer(FixtureMultipleCandidateService service) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidateOne.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidateOne.java
@@ -1,0 +1,10 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(property = "spec.name", value = "non-unique")
+@Requires(env = "di-validator-test")
+final class FixtureMultipleCandidateOne implements FixtureMultipleCandidateService {
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidateOrderConsumer.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidateOrderConsumer.java
@@ -1,0 +1,12 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+
+@Context
+@Requires(property = "spec.name", value = "non-unique-order")
+@Requires(env = "di-validator-test")
+final class FixtureMultipleCandidateOrderConsumer {
+    FixtureMultipleCandidateOrderConsumer(FixtureMultipleCandidateService service) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidateOrderHighPrecedence.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidateOrderHighPrecedence.java
@@ -1,0 +1,12 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Order;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Order(10)
+@Requires(property = "spec.name", value = "non-unique-order")
+@Requires(env = "di-validator-test")
+final class FixtureMultipleCandidateOrderHighPrecedence implements FixtureMultipleCandidateService {
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidateOrderLowPrecedence.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidateOrderLowPrecedence.java
@@ -1,0 +1,12 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Order;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Order(20)
+@Requires(property = "spec.name", value = "non-unique-order")
+@Requires(env = "di-validator-test")
+final class FixtureMultipleCandidateOrderLowPrecedence implements FixtureMultipleCandidateService {
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidatePrimaryBean.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidatePrimaryBean.java
@@ -1,0 +1,12 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Primary
+@Singleton
+@Requires(property = "spec.name", value = "non-unique-primary")
+@Requires(env = "di-validator-test")
+final class FixtureMultipleCandidatePrimaryBean implements FixtureMultipleCandidateService {
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidatePrimaryConsumer.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidatePrimaryConsumer.java
@@ -1,0 +1,12 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+
+@Context
+@Requires(property = "spec.name", value = "non-unique-primary")
+@Requires(env = "di-validator-test")
+final class FixtureMultipleCandidatePrimaryConsumer {
+    FixtureMultipleCandidatePrimaryConsumer(FixtureMultipleCandidateService service) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidatePrimaryFallback.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidatePrimaryFallback.java
@@ -1,0 +1,10 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(property = "spec.name", value = "non-unique-primary")
+@Requires(env = "di-validator-test")
+final class FixtureMultipleCandidatePrimaryFallback implements FixtureMultipleCandidateService {
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidateSecondaryBean.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidateSecondaryBean.java
@@ -1,0 +1,12 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Secondary;
+import jakarta.inject.Singleton;
+
+@Secondary
+@Singleton
+@Requires(property = "spec.name", value = "non-unique-secondary")
+@Requires(env = "di-validator-test")
+final class FixtureMultipleCandidateSecondaryBean implements FixtureMultipleCandidateService {
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidateSecondaryConsumer.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidateSecondaryConsumer.java
@@ -1,0 +1,12 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+
+@Context
+@Requires(property = "spec.name", value = "non-unique-secondary")
+@Requires(env = "di-validator-test")
+final class FixtureMultipleCandidateSecondaryConsumer {
+    FixtureMultipleCandidateSecondaryConsumer(FixtureMultipleCandidateService service) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidateSecondaryPreferred.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidateSecondaryPreferred.java
@@ -1,0 +1,10 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(property = "spec.name", value = "non-unique-secondary")
+@Requires(env = "di-validator-test")
+final class FixtureMultipleCandidateSecondaryPreferred implements FixtureMultipleCandidateService {
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidateService.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidateService.java
@@ -1,0 +1,4 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+interface FixtureMultipleCandidateService {
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidateTwo.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureMultipleCandidateTwo.java
@@ -1,0 +1,10 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(property = "spec.name", value = "non-unique")
+@Requires(env = "di-validator-test")
+final class FixtureMultipleCandidateTwo implements FixtureMultipleCandidateService {
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureNestedDependencyA.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureNestedDependencyA.java
@@ -1,0 +1,12 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+
+@Context
+@Requires(env = "di-validator-test")
+@Requires(property = "spec.name", value = "nested")
+public final class FixtureNestedDependencyA {
+    FixtureNestedDependencyA(FixtureNestedDependencyB nestedDependencyB) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureNestedDependencyB.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureNestedDependencyB.java
@@ -1,0 +1,12 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(env = "di-validator-test")
+@Requires(property = "spec.name", value = "nested")
+public final class FixtureNestedDependencyB {
+    FixtureNestedDependencyB(FixtureMissingDependency missingDependency) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixturePropertyInjectionBean.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixturePropertyInjectionBean.java
@@ -1,0 +1,12 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+
+@Context
+@Requires(env = "di-validator-test")
+public final class FixturePropertyInjectionBean {
+    @Property(name = "spec.missing.property")
+    String value;
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureQualifierInjectionBean.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureQualifierInjectionBean.java
@@ -1,0 +1,16 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Named;
+
+/**
+ * Test fixture bean used to validate qualifier-aware dependency resolution metadata.
+ */
+@Context
+@Requires(property = "spec.name", value = "qualifier")
+@Requires(env = "di-validator-test")
+public final class FixtureQualifierInjectionBean {
+    FixtureQualifierInjectionBean(@Named("primary") FixtureMissingDependency missingDependency) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureScheduledBean.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureScheduledBean.java
@@ -15,6 +15,7 @@ public final class FixtureScheduledBean {
     FixtureMissingDependency missingDependency;
 
     @Scheduled(fixedDelay = "10m")
+    @SuppressWarnings("java:S1186")
     void run() {
     }
 }

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureScheduledBean.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureScheduledBean.java
@@ -1,0 +1,20 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.scheduling.annotation.Scheduled;
+import jakarta.inject.Inject;
+
+/**
+ * Test fixture bean used to validate scheduled entry-point dependency checks.
+ */
+@Context
+@Requires(env = "di-validator-test")
+public final class FixtureScheduledBean {
+    @Inject
+    FixtureMissingDependency missingDependency;
+
+    @Scheduled(fixedDelay = "10m")
+    void run() {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureStartupListenerBean.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureStartupListenerBean.java
@@ -1,0 +1,20 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.runtime.server.event.ServerStartupEvent;
+import jakarta.inject.Singleton;
+
+/**
+ * Test fixture startup listener used to validate event-listener root dependency checks.
+ */
+@Singleton
+@Requires(env = "di-validator-test")
+public final class FixtureStartupListenerBean implements ApplicationEventListener<ServerStartupEvent> {
+    FixtureStartupListenerBean(FixtureMissingDependency missingDependency) {
+    }
+
+    @Override
+    public void onApplicationEvent(ServerStartupEvent event) {
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureStartupListenerBean.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureStartupListenerBean.java
@@ -15,6 +15,7 @@ public final class FixtureStartupListenerBean implements ApplicationEventListene
     }
 
     @Override
+    @SuppressWarnings("java:S1186")
     public void onApplicationEvent(ServerStartupEvent event) {
     }
 }

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureValueInjectionBean.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/FixtureValueInjectionBean.java
@@ -1,0 +1,15 @@
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
+
+/**
+ * Test fixture bean that exercises missing required {@code @Value} property validation.
+ */
+@Context
+@Requires(env = "di-validator-test")
+public final class FixtureValueInjectionBean {
+    @Value("${spec.missing.value}")
+    String value;
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliTest.java
@@ -232,6 +232,62 @@ class ConfigurationJsonSchemaValidatorCliTest {
     }
 
     @Test
+    void dependencyInjectionJsonReportsFactoryMethodInjectionPointForProducedBeanFailures() throws Exception {
+        System.setProperty("spec.name", "factory-method-missing-arg");
+        Path out = tempDir.resolve("out-di-factory-json");
+        int exit = ConfigurationJsonSchemaValidatorCli.run(new String[] {
+            "--classpath", System.getProperty("java.class.path"),
+            "--environments", "test,di-validator-test",
+            "--out", out.toString(),
+            "--validate-dependency-injection",
+            "--format", "json"
+        }, System.out, System.err);
+
+        assertEquals(1, exit);
+        String json = Files.readString(out.resolve("configuration-errors.json"), StandardCharsets.UTF_8);
+        Object decoded = JsonMapper.createDefault().readValue(json, Argument.of(Object.class));
+        assertInstanceOf(Map.class, decoded);
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> diErrors = (List<Map<String, Object>>) ((Map<String, Object>) decoded).get("dependencyInjectionErrors");
+        assertTrue(diErrors.stream().anyMatch(e -> {
+            Object details = e.get("details");
+            Object injectionPoint = e.get("injectionPoint");
+            Object snippet = e.get("snippet");
+            if (details == null || injectionPoint == null || snippet == null) {
+                return false;
+            }
+            String detailsText = String.valueOf(details);
+            String injectionPointText = String.valueOf(injectionPoint);
+            String snippetText = String.valueOf(snippet);
+            return detailsText.contains("No bean of type [java.lang.String] exists")
+                && injectionPointText.contains("method FixtureFactoryMethodMissingArgFactory.greeter(str)")
+                && snippetText.contains("FixtureFactoryMethodMissingArgFactory.greeter")
+                && !injectionPointText.contains("constructor FixtureFactoryMethodMissingArgGreeter(str)");
+        }), () -> "Expected factory method DI injection point in JSON output, got: " + diErrors);
+    }
+
+    @Test
+    void dependencyInjectionHtmlReportsFactoryMethodInjectionPointForProducedBeanFailures() throws Exception {
+        System.setProperty("spec.name", "factory-method-missing-arg");
+        Path out = tempDir.resolve("out-di-factory-html");
+        int exit = ConfigurationJsonSchemaValidatorCli.run(new String[] {
+            "--classpath", System.getProperty("java.class.path"),
+            "--environments", "test,di-validator-test",
+            "--out", out.toString(),
+            "--validate-dependency-injection",
+            "--format", "html"
+        }, System.out, System.err);
+
+        assertEquals(1, exit);
+        String html = Files.readString(out.resolve("configuration-errors.html"), StandardCharsets.UTF_8);
+        assertTrue(html.contains("No bean of type [java.lang.String] exists"), () -> "Expected missing String DI error, got:\n" + html);
+        assertTrue(html.contains("method FixtureFactoryMethodMissingArgFactory.greeter(str)"), () -> "Expected factory method injection point in HTML, got:\n" + html);
+        assertTrue(html.contains("FixtureFactoryMethodMissingArgFactory.greeter"), () -> "Expected factory method snippet in HTML details, got:\n" + html);
+        assertFalse(html.contains("constructor FixtureFactoryMethodMissingArgGreeter(str)"), () -> "Should not report produced bean constructor injection point for factory method dependency failures, got:\n" + html);
+    }
+
+    @Test
     void bootstrapCliCanRunWithMinimalProcessClasspath() throws Exception {
         Path cpDir = tempDir.resolve("cp-bootstrap");
         Files.createDirectories(cpDir);

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliTest.java
@@ -50,6 +50,7 @@ class ConfigurationJsonSchemaValidatorCliTest {
         System.clearProperty("test.config.extra");
         System.clearProperty("micronaut.http.client.unknown");
         System.clearProperty("micronaut.environments");
+        System.clearProperty("spec.name");
     }
 
     @Test
@@ -123,6 +124,17 @@ class ConfigurationJsonSchemaValidatorCliTest {
     }
 
     @Test
+    void optionsCanEnableDependencyInjectionValidation() {
+        ConfigurationJsonSchemaValidatorCli.Options options = ConfigurationJsonSchemaValidatorCli.Options.parse(new String[] {
+            "--classpath", "cp",
+            "--out", tempDir.resolve("out").toString(),
+            "--validate-dependency-injection"
+        });
+
+        assertTrue(options.validateDependencyInjection());
+    }
+
+    @Test
     void suppressionPatternsDowngradeErrorsToWarnings() throws Exception {
         System.setProperty("micronaut.http.client.unknown", "x");
 
@@ -141,13 +153,82 @@ class ConfigurationJsonSchemaValidatorCliTest {
         String json = Files.readString(out.resolve("configuration-errors.json"), StandardCharsets.UTF_8);
         Object decoded = JsonMapper.createDefault().readValue(json, Argument.of(Object.class));
         assertNotNull(decoded);
+        assertInstanceOf(Map.class, decoded);
 
         @SuppressWarnings("unchecked")
-        List<Map<String, Object>> list = (List<Map<String, Object>>) decoded;
+        List<Map<String, Object>> list = (List<Map<String, Object>>) ((Map<String, Object>) decoded).get("configurationErrors");
         assertFalse(list.isEmpty());
         assertTrue(list.stream().anyMatch(m -> "micronaut.http.client.unknown".equals(m.get("property"))));
         assertTrue(list.stream().anyMatch(m -> "WARNING".equals(m.get("type"))));
         assertFalse(list.stream().anyMatch(m -> "ERROR".equals(m.get("type"))));
+    }
+
+    @Test
+    void dependencyInjectionValidationCanBeEnabledFromCli() throws Exception {
+        Path out = tempDir.resolve("out-di");
+        int exit = ConfigurationJsonSchemaValidatorCli.run(new String[] {
+            "--classpath", System.getProperty("java.class.path"),
+            "--environments", "test,di-validator-test",
+            "--out", out.toString(),
+            "--validate-dependency-injection",
+            "--format", "json"
+        }, System.out, System.err);
+
+        assertEquals(1, exit);
+        String json = Files.readString(out.resolve("configuration-errors.json"), StandardCharsets.UTF_8);
+        Object decoded = JsonMapper.createDefault().readValue(json, Argument.of(Object.class));
+        assertInstanceOf(Map.class, decoded);
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> diErrors = (List<Map<String, Object>>) ((Map<String, Object>) decoded).get("dependencyInjectionErrors");
+        assertFalse(diErrors.isEmpty(), () -> "Expected dependency injection errors, got: " + decoded);
+        assertTrue(diErrors.stream().allMatch(e -> e.containsKey("injectionPoint") && e.containsKey("bean") && e.containsKey("details")),
+            () -> "Expected aligned DI JSON fields (injectionPoint, bean, details), got: " + diErrors);
+        assertTrue(diErrors.stream().noneMatch(e -> e.containsKey("rootBean") || e.containsKey("sourceLocation") || e.containsKey("message") || e.containsKey("disabledReason")),
+            () -> "Expected legacy DI JSON fields removed, got: " + diErrors);
+        assertTrue(diErrors.stream().anyMatch(e -> {
+            Object snippet = e.get("snippet");
+            return snippet != null && !String.valueOf(snippet).isBlank();
+        }), () -> "Expected DI errors to include snippet, got: " + diErrors);
+        assertTrue(diErrors.stream().noneMatch(e -> {
+            Object bean = e.get("bean");
+            if (bean == null) {
+                return false;
+            }
+            String value = String.valueOf(bean);
+            return value.contains("io.micronaut.context.env.Environment")
+                || value.contains("io.micronaut.core.value.PropertyResolver");
+        }), () -> "Implicit infrastructure beans should be excluded from DI errors, got: " + diErrors);
+    }
+
+    @Test
+    void dependencyInjectionHtmlReportIncludesSourceSnippetForFailingBean() throws Exception {
+        Path out = tempDir.resolve("out-di-html");
+        int exit = ConfigurationJsonSchemaValidatorCli.run(new String[] {
+            "--classpath", System.getProperty("java.class.path"),
+            "--environments", "test,di-validator-test",
+            "--out", out.toString(),
+            "--validate-dependency-injection",
+            "--format", "html"
+        }, System.out, System.err);
+
+        assertEquals(1, exit);
+        String html = Files.readString(out.resolve("configuration-errors.html"), StandardCharsets.UTF_8);
+        assertTrue(html.contains("Dependency injection errors"));
+        assertFalse(html.contains("<th style='width:10%'>Source</th>"), () -> "Source column should be removed, got:\n" + html);
+        assertFalse(html.contains("<th style='width:14%'>Root</th>"), () -> "Root column should be removed, got:\n" + html);
+        assertTrue(html.contains("<th style='width:42%'>Details</th>"), () -> "Details column missing, got:\n" + html);
+        assertTrue(html.contains("No bean of type [io.micronaut.jsonschema.configuration.validator.FixtureMissingDependency] exists"),
+            () -> "Expected metadata DI error message in HTML, got:\n" + html);
+        assertTrue(html.contains("method FixtureMethodInjectionBean.inject(missingDependency)")
+                || html.contains("field FixtureFieldInjectionBean.missingDependency"),
+            () -> "Expected injection point column first content, got:\n" + html);
+        assertTrue(html.contains("<details>"), () -> "Expected details snippet block in HTML, got:\n" + html);
+        assertTrue(html.contains("FixtureCliDisabledCandidateProperty"), () -> "Expected disabled property candidate in HTML, got:\n" + html);
+        assertTrue(html.contains("FixtureCliDisabledCandidateBean"), () -> "Expected disabled bean candidate in HTML, got:\n" + html);
+        assertTrue(html.contains("More details") || html.contains("mn-detail-main"),
+            () -> "Expected expanded details formatting for DI details column, got:\n" + html);
+        assertFalse(html.contains("missing io.micronaut.context.env.Environment"), () -> "Environment should not be reported as missing, got:\n" + html);
+        assertFalse(html.contains("missing io.micronaut.core.value.PropertyResolver"), () -> "PropertyResolver should not be reported as missing, got:\n" + html);
     }
 
     @Test
@@ -606,4 +687,5 @@ class ConfigurationJsonSchemaValidatorCliTest {
         assertTrue(Pattern.compile("config/application\\.yml:[0-9]+", Pattern.CASE_INSENSITIVE).matcher(stderr).find(),
             () -> "Expected origin to be rewritten using second resources dir, got:\n" + stderr);
     }
+
 }

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliTest.java
@@ -18,7 +18,6 @@ package io.micronaut.jsonschema.configuration.validator.cli;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.json.JsonMapper;
 import io.micronaut.core.type.Argument;
-import io.micronaut.jsonschema.configuration.validator.ConfigurationJsonSchemaValidator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliTest.java
@@ -135,6 +135,18 @@ class ConfigurationJsonSchemaValidatorCliTest {
     }
 
     @Test
+    void optionsCanParseSuppressInjectErrorsPatterns() {
+        ConfigurationJsonSchemaValidatorCli.Options options = ConfigurationJsonSchemaValidatorCli.Options.parse(new String[] {
+            "--classpath", "cp",
+            "--out", tempDir.resolve("out").toString(),
+            "--suppress-inject-errors", "com.example.Foo,com.example.*",
+            "--suppress-inject-errors", "org.example.Bar"
+        });
+
+        assertEquals(List.of("com.example.Foo", "com.example.*", "org.example.Bar"), options.suppressedInjectionErrors());
+    }
+
+    @Test
     void suppressionPatternsDowngradeErrorsToWarnings() throws Exception {
         System.setProperty("micronaut.http.client.unknown", "x");
 
@@ -198,6 +210,59 @@ class ConfigurationJsonSchemaValidatorCliTest {
             return value.contains("io.micronaut.context.env.Environment")
                 || value.contains("io.micronaut.core.value.PropertyResolver");
         }), () -> "Implicit infrastructure beans should be excluded from DI errors, got: " + diErrors);
+    }
+
+    @Test
+    void dependencyInjectionErrorsCanBeSuppressedByExactClassName() throws Exception {
+        Path baselineOut = tempDir.resolve("out-di-baseline");
+        int baselineExit = ConfigurationJsonSchemaValidatorCli.run(new String[] {
+            "--classpath", System.getProperty("java.class.path"),
+            "--environments", "test,di-validator-test",
+            "--out", baselineOut.toString(),
+            "--validate-dependency-injection",
+            "--format", "json"
+        }, System.out, System.err);
+        assertEquals(1, baselineExit);
+        List<Map<String, Object>> baselineDiErrors = readDependencyInjectionErrors(baselineOut);
+        assertTrue(baselineDiErrors.stream().anyMatch(e -> {
+                Object injectionPoint = e.get("injectionPoint");
+                return injectionPoint != null && String.valueOf(injectionPoint).contains("constructor FixtureContextBean(");
+            }),
+            () -> "Expected baseline DI errors to include FixtureContextBean root, got: " + baselineDiErrors);
+
+        Path suppressedOut = tempDir.resolve("out-di-exact-suppressed");
+        int suppressedExit = ConfigurationJsonSchemaValidatorCli.run(new String[] {
+            "--classpath", System.getProperty("java.class.path"),
+            "--environments", "test,di-validator-test",
+            "--out", suppressedOut.toString(),
+            "--validate-dependency-injection",
+            "--suppress-inject-errors", "io.micronaut.jsonschema.configuration.validator.FixtureContextBean",
+            "--format", "json"
+        }, System.out, System.err);
+        assertEquals(1, suppressedExit);
+        List<Map<String, Object>> suppressedDiErrors = readDependencyInjectionErrors(suppressedOut);
+        assertFalse(suppressedDiErrors.stream().anyMatch(e -> {
+                Object injectionPoint = e.get("injectionPoint");
+                return injectionPoint != null && String.valueOf(injectionPoint).contains("constructor FixtureContextBean(");
+            }),
+            () -> "Expected FixtureContextBean DI errors to be suppressed, got: " + suppressedDiErrors);
+    }
+
+    @Test
+    void dependencyInjectionErrorsCanBeSuppressedByPackagePattern() throws Exception {
+        Path out = tempDir.resolve("out-di-package-suppressed");
+        int exit = ConfigurationJsonSchemaValidatorCli.run(new String[] {
+            "--classpath", System.getProperty("java.class.path"),
+            "--environments", "test,di-validator-test",
+            "--out", out.toString(),
+            "--validate-dependency-injection",
+            "--suppress-inject-errors", "io.micronaut.jsonschema.configuration.validator.*",
+            "--format", "json"
+        }, System.out, System.err);
+
+        assertEquals(0, exit);
+        List<Map<String, Object>> diErrors = readDependencyInjectionErrors(out);
+        assertTrue(diErrors.isEmpty(), () -> "Expected package-suppressed DI errors to be empty, got: " + diErrors);
     }
 
     @Test
@@ -742,6 +807,18 @@ class ConfigurationJsonSchemaValidatorCliTest {
         String stderr = errCapture.toString(StandardCharsets.UTF_8);
         assertTrue(Pattern.compile("config/application\\.yml:[0-9]+", Pattern.CASE_INSENSITIVE).matcher(stderr).find(),
             () -> "Expected origin to be rewritten using second resources dir, got:\n" + stderr);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> readDependencyInjectionErrors(Path out) throws Exception {
+        String json = Files.readString(out.resolve("configuration-errors.json"), StandardCharsets.UTF_8);
+        Object decoded = JsonMapper.createDefault().readValue(json, Argument.of(Object.class));
+        assertInstanceOf(Map.class, decoded);
+        Object errors = ((Map<String, Object>) decoded).get("dependencyInjectionErrors");
+        if (errors == null) {
+            return List.of();
+        }
+        return (List<Map<String, Object>>) errors;
     }
 
 }

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/management/InjectErrorsEndpointDisabledTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/management/InjectErrorsEndpointDisabledTest.java
@@ -1,0 +1,28 @@
+package io.micronaut.jsonschema.configuration.validator.management;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.jsonschema.configuration.validator.ConfigurationValidatorConfiguration;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Property(name = ConfigurationValidatorConfiguration.PREFIX + ".dependency-injection.enabled", value = StringUtils.TRUE)
+@Property(name = ConfigurationValidatorConfiguration.PREFIX + ".injecterrors.endpoint.enabled", value = StringUtils.FALSE)
+@Property(name = "endpoints.injecterrors.enabled", value = StringUtils.TRUE)
+@Property(name = "spec.name", value = "field")
+@MicronautTest
+class InjectErrorsEndpointDisabledTest {
+
+    @Test
+    void injectErrorsEndpointCanBeDisabled(@Client("/") HttpClient httpClient) {
+        BlockingHttpClient client = httpClient.toBlocking();
+        assertThrows(HttpClientResponseException.class, () -> client.exchange(HttpRequest.GET("/injecterrors")));
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/management/InjectErrorsEndpointTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/management/InjectErrorsEndpointTest.java
@@ -1,0 +1,35 @@
+package io.micronaut.jsonschema.configuration.validator.management;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.jsonschema.configuration.validator.ConfigurationValidatorConfiguration;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Property(name = ConfigurationValidatorConfiguration.PREFIX + ".dependency-injection.enabled", value = StringUtils.TRUE)
+@Property(name = "spec.name", value = "field")
+@Property(name = "endpoints.injecterrors.sensitive", value = StringUtils.FALSE)
+@MicronautTest
+class InjectErrorsEndpointTest {
+
+    @Test
+    void injectErrorsEndpointExposesErrorsNamespace(@Client("/") HttpClient httpClient) {
+        BlockingHttpClient client = httpClient.toBlocking();
+        Map<String, Object> decoded = assertDoesNotThrow(() -> client.retrieve(HttpRequest.GET("/injecterrors"), Argument.mapOf(String.class, Object.class)));
+        assertTrue(decoded.containsKey("errors"), () -> "Unexpected response: " + decoded);
+        Object errors = decoded.get("errors");
+        assertInstanceOf(List.class, errors, () -> "Expected list, got: " + errors);
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/management/InjectErrorsHealthIndicatorDisabledTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/management/InjectErrorsHealthIndicatorDisabledTest.java
@@ -1,0 +1,30 @@
+package io.micronaut.jsonschema.configuration.validator.management;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.jsonschema.configuration.validator.ConfigurationValidatorConfiguration;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Property(name = ConfigurationValidatorConfiguration.PREFIX + ".dependency-injection.enabled", value = StringUtils.TRUE)
+@Property(name = ConfigurationValidatorConfiguration.ENDPOINT_PREFIX + ".enabled", value = StringUtils.FALSE)
+@Property(name = "spec.name", value = "field")
+@MicronautTest
+class InjectErrorsHealthIndicatorDisabledTest {
+    @Test
+    void healthIndicatorCanBeDisabled(@Client("/") HttpClient httpClient) {
+        BlockingHttpClient client = httpClient.toBlocking();
+        Map<String, Object> decoded = assertDoesNotThrow(() -> client.retrieve(HttpRequest.GET("/health/liveness"), Argument.mapOf(String.class, Object.class)));
+        assertEquals("UP", decoded.get("status"), () -> "Unexpected response: " + decoded);
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/management/InjectErrorsHealthIndicatorTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/management/InjectErrorsHealthIndicatorTest.java
@@ -1,0 +1,32 @@
+package io.micronaut.jsonschema.configuration.validator.management;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.jsonschema.configuration.validator.ConfigurationValidatorConfiguration;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Property(name = ConfigurationValidatorConfiguration.PREFIX + ".dependency-injection.enabled", value = StringUtils.TRUE)
+@Property(name = "spec.name", value = "field")
+@MicronautTest
+class InjectErrorsHealthIndicatorTest {
+    @Test
+    void healthIndicatorReportsDownWhenInjectErrorsPresent(@Client("/") HttpClient httpClient) {
+        BlockingHttpClient client = httpClient.toBlocking();
+        HttpClientResponseException ex = assertThrows(HttpClientResponseException.class, () -> client.retrieve("/health"));
+        Optional<Map<String, Object>> response = ex.getResponse().getBody(Argument.mapOf(String.class, Object.class));
+        Map<String, Object> decoded = response.get();
+        assertEquals("DOWN", decoded.get("status"), () -> "Unexpected response: " + decoded);
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/report/ConfigurationErrorReporterTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/report/ConfigurationErrorReporterTest.java
@@ -148,4 +148,29 @@ class ConfigurationErrorReporterTest {
 
         assertTrue(html.contains("No configuration validation errors"));
     }
+
+    @Test
+    void systemErrReporterDoesNotTruncateOriginPathAndLineReference() throws Exception {
+        String origin = "src/main/resources/application.properties";
+        Set<ConfigurationError> errors = Set.of(new ConfigurationError(
+            "micronaut.server.port",
+            ConfigurationError.Type.ERROR,
+            "must be integer",
+            origin,
+            "micronaut.server.port",
+            "junk",
+            123,
+            null,
+            null
+        ));
+
+        String out;
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             PrintStream ps = new PrintStream(baos, true, StandardCharsets.UTF_8)) {
+            new SystemErrConfigurationErrorReporter(ps).report(errors, Set.of());
+            out = baos.toString(StandardCharsets.UTF_8);
+        }
+
+        assertTrue(out.contains(origin + ":123"), () -> "Expected full origin path with line number, got:\n" + out);
+    }
 }

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/report/ConfigurationErrorReporterTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/report/ConfigurationErrorReporterTest.java
@@ -17,12 +17,15 @@ package io.micronaut.jsonschema.configuration.validator.report;
 
 import io.micronaut.json.JsonMapper;
 import io.micronaut.jsonschema.configuration.validator.ConfigurationError;
+import io.micronaut.jsonschema.configuration.validator.DependencyInjectionError;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -33,26 +36,40 @@ class ConfigurationErrorReporterTest {
     void systemErrReporterPrintsToSystemErr() throws Exception {
         Set<ConfigurationError> errors = new LinkedHashSet<>();
         errors.add(new ConfigurationError("a.b", "msg", "origin", "raw", "<bad>"));
+        Set<DependencyInjectionError> dependencyInjectionErrors = Set.of(new DependencyInjectionError(
+            "example.Root",
+            "example.Bean",
+            "No bean of type [example.Missing] exists",
+            "field dependency",
+            "Disabled by @Requires",
+            List.of("* example.Root", "* example.Bean"),
+            null,
+            null
+        ));
 
         PrintStream original = System.err;
         String out;
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
              PrintStream ps = new PrintStream(baos, true, StandardCharsets.UTF_8)) {
             System.setErr(ps);
-            new SystemErrConfigurationErrorReporter().report(errors);
+            new SystemErrConfigurationErrorReporter().report(errors, dependencyInjectionErrors);
             out = baos.toString(StandardCharsets.UTF_8);
         } finally {
             System.setErr(original);
         }
 
         assertTrue(out.contains("a.b"));
-        assertTrue(out.contains("Configuration Validation Errors Present"));
+        assertTrue(out.contains("Validation Errors Present"));
         assertTrue(out.contains("Property"));
         assertTrue(out.contains("Type"));
         assertTrue(out.contains("Message"));
         assertTrue(out.contains("Origin"));
         assertTrue(out.contains("msg"));
         assertTrue(out.contains("origin"));
+        assertTrue(out.contains("Dependency Injection Errors"));
+        assertTrue(out.contains("Bean"));
+        assertTrue(out.contains("Disabled:"));
+        assertTrue(out.contains("+-->"));
         assertFalse(out.contains("origin:-1"), () -> "Unexpected origin line number formatting: " + out);
         assertTrue(out.contains("<bad>"));
     }
@@ -67,8 +84,10 @@ class ConfigurationErrorReporterTest {
 
         Object decoded = JsonMapper.createDefault().readValue(json, io.micronaut.core.type.Argument.of(Object.class));
         assertNotNull(decoded);
+        assertInstanceOf(Map.class, decoded);
         assertTrue(json.contains("\"property\""));
         assertTrue(json.contains("\"a.b\""));
+        assertTrue(json.contains("\"configurationErrors\""));
         assertTrue(json.contains("\"lineNumber\""));
         assertFalse(json.contains("snippet"));
     }
@@ -87,7 +106,16 @@ class ConfigurationErrorReporterTest {
         ));
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        new HtmlConfigurationErrorReporter(baos).report(errors);
+        new HtmlConfigurationErrorReporter(baos).report(errors, Set.of(new DependencyInjectionError(
+            "a.Root",
+            "a.Bean",
+            "broken",
+            "field test",
+            null,
+            List.of("* a.Root", "* a.Bean"),
+            null,
+            null
+        )));
         String html = baos.toString(StandardCharsets.UTF_8);
 
         assertTrue(html.contains("<html"));
@@ -95,6 +123,13 @@ class ConfigurationErrorReporterTest {
         assertTrue(html.contains("highlight"));
         assertTrue(html.contains("micronaut-logo-white.svg"));
         assertTrue(html.contains("Configuration validation errors"));
+        assertTrue(html.contains("Dependency injection errors"));
+        assertTrue(html.contains("Dependency injection failure paths"));
+        assertTrue(html.contains("data:image/svg+xml;base64,"));
+        assertFalse(html.contains("<th style='width:14%'>Root</th>"));
+        assertFalse(html.contains("<th style='width:10%'>Source</th>"));
+        assertTrue(html.contains("<th style='width:42%'>Details</th>"));
+        assertTrue(html.contains("More details") || html.contains("mn-detail-main"));
         assertTrue(html.contains("a&lt;b"));
         assertTrue(html.contains("m&amp;g"));
         assertTrue(html.contains("o&quot;r"));
@@ -108,7 +143,7 @@ class ConfigurationErrorReporterTest {
     void htmlReporterRendersSuccessForNoErrors() throws Exception {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        new HtmlConfigurationErrorReporter(baos).report(Set.of());
+        new HtmlConfigurationErrorReporter(baos).report(Set.of(), Set.of());
         String html = baos.toString(StandardCharsets.UTF_8);
 
         assertTrue(html.contains("No configuration validation errors"));

--- a/src/main/docs/guide/configurationValidator.adoc
+++ b/src/main/docs/guide/configurationValidator.adoc
@@ -75,10 +75,13 @@ java -cp <full-classpath> io.micronaut.jsonschema.configuration.validator.cli.Co
   --environments test \
   --out build/reports/config-schema \
   --format both \
+  --suppress-inject-errors com.example.LegacyBean,com.example.generated.* \
   --validate-dependency-injection
 ----
 
 When enabled, console, JSON, and HTML outputs include a dedicated DI section (errors + dependency failure paths).
+
+Use `--suppress-inject-errors` to suppress DI errors for specific bean classes or packages. Patterns support exact fully-qualified class names and `*` wildcards (for example `com.example.LegacyBean` or `com.example.generated.*`).
 
 The JSON report (`configuration-errors.json`) adds a `dependencyInjectionErrors` array containing entries such as:
 

--- a/src/main/docs/guide/configurationValidator.adoc
+++ b/src/main/docs/guide/configurationValidator.adoc
@@ -52,6 +52,74 @@ If an error originates from a resolvable file (for example `application.properti
 
 The HTML report includes an expandable snippet preview with syntax highlighting. The JSON report includes only the line number.
 
+=== Dependency injection validation
+
+In addition to schema/property validation, the validator can also perform metadata-only dependency injection checks.
+
+This catches wiring issues before application startup, including:
+
+* missing bean dependencies
+* circular dependencies
+* disabled candidate beans (with `@Requires` reasons)
+* ambiguous candidates that would fail with a non-unique bean error at runtime
+* unresolved dependencies of `@Factory`-produced beans
+
+==== CLI usage
+
+Enable DI validation by adding `--validate-dependency-injection`:
+
+[source,bash]
+----
+java -cp <full-classpath> io.micronaut.jsonschema.configuration.validator.cli.ConfigurationJsonSchemaValidatorCli \
+  --classpath <full-classpath> \
+  --environments test \
+  --out build/reports/config-schema \
+  --format both \
+  --validate-dependency-injection
+----
+
+When enabled, console, JSON, and HTML outputs include a dedicated DI section (errors + dependency failure paths).
+
+The JSON report (`configuration-errors.json`) adds a `dependencyInjectionErrors` array containing entries such as:
+
+* `rootBean`
+* `bean`
+* `injectionPoint`
+* `details`
+* `disabledReason` (when applicable)
+* `failingPath`
+
+==== Runtime API and management integration
+
+When `micronaut-management` is present and DI validation is enabled, the module also exposes DI results at runtime:
+
+* api:jsonschema.configuration.validator.DependencyInjectionErrors[] API
+* management endpoint id `injecterrors` (property: `micronaut.jsonschema.configuration.validator.injecterrors.endpoint.enabled`)
+* health indicator id `injecterrors` (property: `endpoints.health.injecterrors.enabled`)
+
+Example endpoint configuration:
+
+[configuration]
+----
+micronaut:
+  jsonschema:
+    configuration:
+      validator:
+        dependency-injection:
+          enabled: true
+        injecterrors:
+          endpoint:
+            enabled: true
+endpoints:
+  all:
+    sensitive: false
+  injecterrors:
+    sensitive: false
+  health:
+    injecterrors:
+      enabled: true
+----
+
 === Runtime integration (optional)
 
 In addition to the CLI, the configuration validator module also provides optional runtime integrations:


### PR DESCRIPTION
## Summary
- Add metadata-only Dependency Injection validation as a first-class validation feature, including validator APIs, CLI integration, endpoint/health exposure, and JSON/HTML/console report output.
- Detect and report unresolved injections, circular dependencies, disabled candidates with reasons, and `@EachProperty`/`@EachBean` configuration-chain failures (including nested `@EachBean` chains).
- Expand test coverage with dedicated DI fixtures and CLI/report regression tests, including improved HTML details formatting and failure-path graph rendering.

## Why
Runtime DI failures are costly and often discovered late. This adds pre-runtime DI validation so configuration and bean wiring issues are surfaced early with actionable diagnostics.

## Notes
- Uses metadata analysis only (no bean instantiation for validation logic).
- Test fixtures were moved to `src/test/java` so test-only code stays out of main sources.

## Example Report

<img width="1248" height="833" alt="Screenshot 2026-02-27 at 15 08 32" src="https://github.com/user-attachments/assets/a2e7f11e-55eb-4ec8-9a97-1d29c212de19" />


