### PR TITLE
fix: honor schema defaults for required config properties

### DIFF
--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationSchemaPropertyAdapter.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationSchemaPropertyAdapter.java
@@ -38,6 +38,7 @@ final class ConfigurationSchemaPropertyAdapter {
             schema.uniqueItems(),
             schema.multipleOf(),
             schema.constValue(),
+            schema.defaultValue(),
             null,
             null,
             null,

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/SchemaValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/SchemaValidator.java
@@ -94,6 +94,13 @@ final class SchemaValidator {
         List<String> required = schema.required();
         if (required != null) {
             for (String req : required) {
+                ConfigurationSchemaProperty requiredProperty = properties.get(req);
+                if (requiredProperty != null) {
+                    ConfigurationSchemaProperty resolvedRequiredProperty = ctx.refResolver().resolveRef(requiredProperty);
+                    if ((resolvedRequiredProperty != null && resolvedRequiredProperty.defaultValue() != null) || requiredProperty.defaultValue() != null) {
+                        continue;
+                    }
+                }
                 if (!instance.containsKey(req)) {
                     String missingComputed = computedPropertyName + "." + req;
                     String missingResolved = ctx.resolvedPropertyName(missingComputed, null, wildcardReplacement);

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/model/ConfigurationSchema.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/model/ConfigurationSchema.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.jsonschema.configuration.validator.model;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.serde.annotation.Serdeable;
@@ -50,6 +51,7 @@ import java.util.Map;
  * @param uniqueItems Whether array items must be unique
  * @param multipleOf Numeric multiple-of constraint
  * @param constValue Constant value constraint
+ * @param defaultValue Default value mapped from {@code default} / {@code defaultValue}
  * @param properties Object properties mapped from {@code properties}
  * @param required Required property names mapped from {@code required}
  * @param minProperties Minimum number of properties for object values
@@ -146,6 +148,11 @@ public record ConfigurationSchema(
      * Constant value constraint.
      */
     @Nullable @JsonProperty("const") Object constValue,
+
+    /**
+     * Default value for the root schema node.
+     */
+    @Nullable @JsonProperty("defaultValue") @JsonAlias("default") Object defaultValue,
 
     /**
      * Object properties mapped from {@code properties}.

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/model/ConfigurationSchemaProperty.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/model/ConfigurationSchemaProperty.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.jsonschema.configuration.validator.model;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.serde.annotation.Serdeable;
@@ -43,6 +44,7 @@ import java.util.Map;
  * @param uniqueItems Whether array items must be unique
  * @param multipleOf Numeric multiple-of constraint
  * @param constValue Constant value constraint
+ * @param defaultValue Default value mapped from {@code default} / {@code defaultValue}
  * @param javaType Micronaut extension for the Java type ({@code x-micronaut-javaType})
  * @param sourceType Micronaut extension for the source type ({@code x-micronaut-sourceType})
  * @param micronautPath Micronaut extension for the resolved config path ({@code x-micronaut-path})
@@ -124,6 +126,11 @@ public record ConfigurationSchemaProperty(
      * Constant value constraint.
      */
     @Nullable @JsonProperty("const") Object constValue,
+
+    /**
+     * Default value for this property, when declared in the schema.
+     */
+    @Nullable @JsonProperty("defaultValue") @JsonAlias("default") Object defaultValue,
 
     /**
      * Micronaut extension that indicates the Java type for conversion/validation.

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidatorTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidatorTest.java
@@ -45,6 +45,24 @@ class ConfigurationJsonSchemaValidatorTest {
         assertTrue(schemas.containsKey("test.enum.EnumConfig.json"));
         assertTrue(schemas.containsKey("test.pattern.PatternConfig.json"));
         assertTrue(schemas.containsKey("test.url.UrlConfig.json"));
+        assertTrue(schemas.containsKey("test.bindable.BindableDefaultsConfig.json"));
+    }
+
+    @Test
+    void doesNotReportMissingRequiredForPropertiesWithSchemaDefault() {
+        Environment environment = createEnvironment(Map.of(
+            "test.bindable.enabled", StringUtils.TRUE
+        ));
+
+        ConfigurationJsonSchemaValidator validator = new ConfigurationJsonSchemaValidator();
+        validator.setFailOnNotPresent(true);
+
+        Set<ConfigurationError> errors = validator.validate(getClass().getClassLoader(), environment);
+
+        assertFalse(errors.stream().anyMatch(e -> e.property().equals("test.bindable.initial-pool-size")
+            && e.message().contains("Missing required")), () -> "Unexpected missing required error for initial-pool-size: " + errors);
+        assertFalse(errors.stream().anyMatch(e -> e.property().equals("test.bindable.max-pool-size")
+            && e.message().contains("Missing required")), () -> "Unexpected missing required error for max-pool-size: " + errors);
     }
 
     @Test

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/ValueCoercerTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/ValueCoercerTest.java
@@ -170,6 +170,7 @@ class ValueCoercerTest {
             null,
             null,
             null,
+            null,
             javaType,
             null,
             null,
@@ -191,6 +192,7 @@ class ValueCoercerTest {
 
     private static ConfigurationSchema emptyRootSchema() {
         return new ConfigurationSchema(
+            null,
             null,
             null,
             null,

--- a/json-schema-configuration-validator/src/test/resources/META-INF/micronaut-configuration-schemas/test.bindable.BindableDefaultsConfig.json
+++ b/json-schema-configuration-validator/src/test/resources/META-INF/micronaut-configuration-schemas/test.bindable.BindableDefaultsConfig.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:micronaut:config:test.bindable.BindableDefaultsConfig",
+  "title": "test.bindable.BindableDefaultsConfig",
+  "x-micronaut": {
+    "prefix": "test.bindable",
+    "type": "test.bindable.BindableDefaultsConfig",
+    "kind": "configuration-properties"
+  },
+  "type": "object",
+  "properties": {
+    "initial-pool-size": {
+      "type": "integer",
+      "default": 1,
+      "x-micronaut-javaType": "java.lang.Integer",
+      "x-micronaut-path": "test.bindable.initial-pool-size"
+    },
+    "max-pool-size": {
+      "type": "integer",
+      "default": 8,
+      "x-micronaut-javaType": "java.lang.Integer",
+      "x-micronaut-path": "test.bindable.max-pool-size"
+    },
+    "enabled": {
+      "type": "boolean",
+      "x-micronaut-javaType": "java.lang.Boolean",
+      "x-micronaut-path": "test.bindable.enabled"
+    }
+  },
+  "required": [
+    "initial-pool-size",
+    "max-pool-size"
+  ]
+}


### PR DESCRIPTION
## Summary
- deserialize JSON Schema `default`/`defaultValue` in configuration-validator schema models and propagate it through root property adaptation
- treat required properties with schema defaults as satisfied during validation to avoid false `Missing required property` errors
- add a regression schema fixture and validator test coverage for interface-style bindable defaults (`initial-pool-size` / `max-pool-size`)

## Verification
- ./gradlew -q :micronaut-json-schema-configuration-validator:compileTestJava :micronaut-json-schema-configuration-validator:compileTestGroovy
- ./gradlew :micronaut-json-schema-configuration-validator:test --tests 'io.micronaut.jsonschema.configuration.validator.ConfigurationJsonSchemaValidatorTest' --tests 'io.micronaut.jsonschema.configuration.validator.ValueCoercerTest'
- ./gradlew :micronaut-json-schema-configuration-validator:test
- ./gradlew -q cM
- ./gradlew -q spotlessCheck