### PR TITLE
Add junit.platform.launcher for test-suite-kotlin

### DIFF
--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     testImplementation(mn.micronaut.inject.java.test)
     testImplementation(mn.micronaut.inject)
     testImplementation(mnTest.micronaut.test.spock)
+    testRuntimeOnly(mnTest.junit.platform.launcher)
 }
 
 ksp {


### PR DESCRIPTION
this PR fix : 
```
Execution failed for task ':test-suite-kotlin:test'.
> Test process encountered an unexpected problem.
   > Could not start Gradle Test Executor 1.
      > Failed to load JUnit Platform.  Please ensure that all JUnit Platform dependen***es are available on the test's runtime classpath, including the JUnit Platform launcher.
```