### PR TITLE
Fix auto.test.resources placeholder resolution in config validator

### DIFF
--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/AutoTestResourcesPropertyExpressionResolver.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/AutoTestResourcesPropertyExpressionResolver.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.env.PropertyExpressionResolver;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.value.PropertyResolver;
+
+import java.util.Optional;
+
+/**
+ * Provides placeholder fallback values for Micronaut Test Resources expressions.
+ */
+@Internal
+public final class AutoTestResourcesPropertyExpressionResolver implements PropertyExpressionResolver {
+    static final String PREFIX = "auto.test.resources.";
+    private static final String DUMMY_TEXT_VALUE = "test-resource";
+
+    @Override
+    public <T> Optional<T> resolve(
+        PropertyResolver propertyResolver,
+        ConversionService conversionService,
+        String expression,
+        Class<T> requiredType
+    ) {
+        if (!expression.startsWith(PREFIX)) {
+            return Optional.empty();
+        }
+        if (requiredType.isAssignableFrom(String.class)) {
+            return Optional.of(requiredType.cast(DUMMY_TEXT_VALUE));
+        }
+
+        Optional<T> converted = conversionService.convert(DUMMY_TEXT_VALUE, requiredType);
+        if (converted.isPresent()) {
+            return converted;
+        }
+
+        converted = conversionService.convert("0", requiredType);
+        if (converted.isPresent()) {
+            return converted;
+        }
+
+        return conversionService.convert("false", requiredType);
+    }
+}

--- a/json-schema-configuration-validator/src/main/resources/META-INF/services/io.micronaut.context.env.PropertyExpressionResolver
+++ b/json-schema-configuration-validator/src/main/resources/META-INF/services/io.micronaut.context.env.PropertyExpressionResolver
@@ -1,0 +1,1 @@
+io.micronaut.jsonschema.configuration.validator.AutoTestResourcesPropertyExpressionResolver

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/AutoTestResourcesPropertyExpressionResolverTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/AutoTestResourcesPropertyExpressionResolverTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.convert.MutableConversionService;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AutoTestResourcesPropertyExpressionResolverTest {
+
+    private final AutoTestResourcesPropertyExpressionResolver resolver = new AutoTestResourcesPropertyExpressionResolver();
+
+    @Test
+    void nonAutoTestResourcesExpressionsRemainUnresolved() {
+        try (Environment environment = newEnvironment()) {
+            assertTrue(resolver.resolve(environment, MutableConversionService.create(), "datasources.default.username", String.class).isEmpty());
+        }
+    }
+
+    @Test
+    void autoTestResourcesExpressionsResolveToDummyString() {
+        try (Environment environment = newEnvironment()) {
+            assertEquals("test-resource", resolver.resolve(environment, MutableConversionService.create(), "auto.test.resources.datasources.default.username", String.class).orElseThrow());
+        }
+    }
+
+    @Test
+    void resolverUsesPrimaryConversionResultWhenAvailable() {
+        try (Environment environment = newEnvironment()) {
+            URI uri = resolver.resolve(environment, MutableConversionService.create(), "auto.test.resources.datasources.default.url", URI.class).orElseThrow();
+            assertEquals(URI.create("test-resource"), uri);
+        }
+    }
+
+    @Test
+    void resolverFallsBackToFalseLiteralWhenRequired() {
+        try (Environment environment = newEnvironment()) {
+            MutableConversionService conversionService = MutableConversionService.create();
+            conversionService.addConverter(String.class, FalseOnlyValue.class, value -> "false".equals(value) ? new FalseOnlyValue(value) : null);
+
+            FalseOnlyValue value = resolver.resolve(environment, conversionService, "auto.test.resources.flag", FalseOnlyValue.class).orElseThrow();
+            assertEquals("false", value.value());
+            assertFalse("0".equals(value.value()));
+        }
+    }
+
+    @Test
+    void resolverFallsBackToZeroLiteralWhenRequired() {
+        try (Environment environment = newEnvironment()) {
+            MutableConversionService conversionService = MutableConversionService.create();
+            conversionService.addConverter(String.class, ZeroOnlyValue.class, value -> "0".equals(value) ? new ZeroOnlyValue(value) : null);
+
+            ZeroOnlyValue value = resolver.resolve(environment, conversionService, "auto.test.resources.port", ZeroOnlyValue.class).orElseThrow();
+            assertEquals("0", value.value());
+        }
+    }
+
+    record FalseOnlyValue(String value) {
+    }
+
+    record ZeroOnlyValue(String value) {
+    }
+
+    private static Environment newEnvironment() {
+        ClassLoader classLoader = AutoTestResourcesPropertyExpressionResolverTest.class.getClassLoader();
+        return Environment.create(new io.micronaut.context.ApplicationContextConfiguration() {
+            @Override
+            public Optional<Boolean> getDeduceEnvironments() {
+                return Optional.of(false);
+            }
+
+            @Override
+            public List<String> getEnvironments() {
+                return List.of();
+            }
+
+            @Override
+            public ClassLoader getClassLoader() {
+                return classLoader;
+            }
+        }).start();
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliTest.java
@@ -752,6 +752,34 @@ class ConfigurationJsonSchemaValidatorCliTest {
     }
 
     @Test
+    void cliResolvesAutoTestResourcesPlaceholdersDuringConfigurationValidation() throws Exception {
+        Path cp = tempDir.resolve("cp-auto-test-resources");
+        Files.createDirectories(cp);
+        Files.writeString(cp.resolve("application.properties"), String.join("\n",
+            "micronaut.application.name=${auto.test.resources.micronaut.application.name}",
+            ""
+        ), StandardCharsets.UTF_8);
+
+        Path out = tempDir.resolve("out-auto-test-resources");
+        ByteArrayOutputStream errCapture = new ByteArrayOutputStream();
+        PrintStream err = new PrintStream(errCapture, true, StandardCharsets.UTF_8);
+
+        String classpath = cp + File.pathSeparator + System.getProperty("java.class.path");
+        int exit = ConfigurationJsonSchemaValidatorCli.run(new String[] {
+            "--classpath", classpath,
+            "--environments", "test",
+            "--out", out.toString(),
+            "--format", "json"
+        }, System.out, err);
+
+        assertEquals(0, exit, () -> "Unexpected stderr:\n" + errCapture.toString(StandardCharsets.UTF_8));
+        assertTrue(Files.exists(out.resolve("configuration-errors.json")));
+
+        String stderr = errCapture.toString(StandardCharsets.UTF_8);
+        assertFalse(stderr.contains("Could not resolve placeholder"), () -> "Unexpected stderr:\n" + stderr);
+    }
+
+    @Test
     void cliRendersRelativeOriginPathsWhenConfigured() throws Exception {
         Path project = tempDir.resolve("project");
         Path resources = project.resolve("src/main/resources");


### PR DESCRIPTION
## Summary
- add a `PropertyExpressionResolver` service that provides safe fallback values for expressions starting with `auto.test.resources.` so validation does not fail before test resources are injected
- register the resolver through `META-INF/services` so it is discovered by Micronaut's placeholder engine during CLI/environment validation
- add a CLI regression test proving `${auto.test.resources...}` placeholders no longer fail configuration validation

## Verification
- `./gradlew :micronaut-json-schema-configuration-validator:test --tests 'io.micronaut.jsonschema.configuration.validator.cli.ConfigurationJsonSchemaValidatorCliTest.cliResolvesAutoTestResourcesPlaceholdersDuringConfigurationValidation'`
- `./gradlew :micronaut-json-schema-configuration-validator:test`
- `./gradlew -q cM`
- `./gradlew -q :micronaut-json-schema-configuration-validator:check`
- `./gradlew -q spotlessCheck`

Closes #315