### PR TITLE
Fix datasource false positives for overlapping each-property schemas

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ micronaut-validation = "5.0.0-M1"
 managed-json-schema-validator = "1.5.9"
 java-parser = "3.28.0"
 micronaut-toml = "2.8.0"
+micronaut-sql = "7.0.0-M7"
 
 [libraries]
 micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut' }
@@ -35,6 +36,7 @@ managed-json-schema-validator = { module = "com.networknt:json-schema-validator"
 java-parser = { module = "com.github.javaparser:javaparser-core", version.ref = "java-parser" }
 
 micronaut-toml = { module = "io.micronaut.toml:micronaut-toml", version.ref = "micronaut-toml" }
+micronaut-sql-jdbc-hikari = { module = "io.micronaut.sql:micronaut-jdbc-hikari", version.ref = "micronaut-sql" }
 
 [bundles]
 

--- a/json-schema-configuration-validator/build.gradle.kts
+++ b/json-schema-configuration-validator/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     testImplementation(mn.micronaut.management)
     testImplementation(mn.micronaut.http.client)
     testImplementation(mn.micronaut.jackson.databind)
+    testImplementation(libs.micronaut.sql.jdbc.hikari)
     testImplementation(mn.snakeyaml)
     testImplementation(libs.micronaut.toml)
 

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidator.java
@@ -138,6 +138,13 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
         for (Map.Entry<String, List<ConfigurationSchema>> entry : schemasByPrefix.entrySet()) {
             String prefix = entry.getKey();
             Set<String> overlappingPrefixKeys = overlappingPrefixKeys(entry.getValue());
+            Set<String> overlappingEachPropertySchemaKeys = overlappingEachPropertySchemaKeys(
+                entry.getValue(),
+                classLoader,
+                environment,
+                mapper,
+                failOnNotPresent
+            );
             for (ConfigurationSchema schema : entry.getValue()) {
                 engine.validateSchema(
                     prefix,
@@ -149,7 +156,8 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
                     rules,
                     errors,
                     nestedSchemaKeysByPrefix,
-                    overlappingPrefixKeys
+                    overlappingPrefixKeys,
+                    overlappingEachPropertySchemaKeys
                 );
             }
         }
@@ -264,6 +272,34 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
         return keys.isEmpty() ? Set.of() : keys;
     }
 
+    private static Set<String> overlappingEachPropertySchemaKeys(
+        List<ConfigurationSchema> schemas,
+        ClassLoader classLoader,
+        Environment environment,
+        JsonMapper jsonMapper,
+        boolean failOnNotPresent
+    ) {
+        if (schemas == null || schemas.size() < 2) {
+            return Set.of();
+        }
+        Set<String> keys = new LinkedHashSet<>(8);
+        for (ConfigurationSchema schema : schemas) {
+            if (schema == null || schema.micronaut() == null) {
+                continue;
+            }
+            if (!"each-property".equals(schema.micronaut().kind()) || !"map".equals(schema.micronaut().container())) {
+                continue;
+            }
+            SchemaContext ctx = new SchemaContext(schema, classLoader, environment, jsonMapper, failOnNotPresent);
+            ConfigurationSchemaProperty entrySchema = ctx.refResolver().resolveAdditionalPropertiesSchema(ConfigurationSchemaPropertyAdapter.fromRoot(schema));
+            if (entrySchema == null || entrySchema.properties() == null || entrySchema.properties().isEmpty()) {
+                continue;
+            }
+            keys.addAll(entrySchema.properties().keySet());
+        }
+        return keys.isEmpty() ? Set.of() : keys;
+    }
+
     /**
      * Internal validation implementation.
      */
@@ -278,13 +314,14 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
             List<ConfigurationRule> rules,
             Set<ConfigurationError> errors,
             Map<String, Set<String>> nestedSchemaKeysByPrefix,
-            Set<String> overlappingPrefixKeys
+            Set<String> overlappingPrefixKeys,
+            Set<String> overlappingEachPropertySchemaKeys
         ) {
             String kind = schema.micronaut() != null ? schema.micronaut().kind() : null;
             String container = schema.micronaut() != null ? schema.micronaut().container() : null;
 
             if ("each-property".equals(kind) && "map".equals(container)) {
-                validateEachProperty(prefix, schema, classLoader, environment, jsonMapper, failOnNotPresent, rules, errors, nestedSchemaKeysByPrefix);
+                validateEachProperty(prefix, schema, classLoader, environment, jsonMapper, failOnNotPresent, rules, errors, nestedSchemaKeysByPrefix, overlappingEachPropertySchemaKeys);
             } else {
                 validateConfigurationProperties(prefix, schema, classLoader, environment, jsonMapper, failOnNotPresent, rules, errors, nestedSchemaKeysByPrefix, overlappingPrefixKeys);
             }
@@ -327,7 +364,8 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
             boolean failOnNotPresent,
             List<ConfigurationRule> rules,
             Set<ConfigurationError> errors,
-            Map<String, Set<String>> nestedSchemaKeysByPrefix
+            Map<String, Set<String>> nestedSchemaKeysByPrefix,
+            Set<String> overlappingEachPropertySchemaKeys
         ) {
             SchemaContext ctx = new SchemaContext(schema, classLoader, environment, jsonMapper, failOnNotPresent);
             ConfigurationSchemaProperty entrySchema = ctx.refResolver().resolveAdditionalPropertiesSchema(ConfigurationSchemaPropertyAdapter.fromRoot(schema));
@@ -349,12 +387,38 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
                 String entryPrefix = prefix + "." + entry;
                 Map<String, Object> flat = environment.getProperties(entryPrefix, StringConvention.HYPHENATED);
                 Map<String, Object> instance = NestedPropertyMapBuilder.nest(flat);
+                Map<String, Object> effectiveInstance = removeOverlappingEachPropertySchemaKeys(instance, entrySchema, overlappingEachPropertySchemaKeys);
 
-                SchemaValidator.validateObject(ctx, entrySchema, instance, entryPrefix, entry, errors);
+                SchemaValidator.validateObject(ctx, entrySchema, effectiveInstance, entryPrefix, entry, errors);
 
                 applyRules(rules, new ConfigurationValidationContext(environment, entryPrefix, schema, entrySchema, instance), errors);
                 applyRulesForNestedObjects(rules, environment, entryPrefix, schema, entrySchema, instance, errors);
             }
+        }
+
+        private static Map<String, Object> removeOverlappingEachPropertySchemaKeys(
+            Map<String, Object> instance,
+            ConfigurationSchemaProperty entrySchema,
+            Set<String> overlappingEachPropertySchemaKeys
+        ) {
+            if (instance.isEmpty() || overlappingEachPropertySchemaKeys.isEmpty()) {
+                return instance;
+            }
+            Map<String, ConfigurationSchemaProperty> properties = entrySchema.properties();
+            Map<String, Object> filtered = null;
+            for (String key : overlappingEachPropertySchemaKeys) {
+                if (!instance.containsKey(key)) {
+                    continue;
+                }
+                if (properties != null && properties.containsKey(key)) {
+                    continue;
+                }
+                if (filtered == null) {
+                    filtered = new LinkedHashMap<>(instance);
+                }
+                filtered.remove(key);
+            }
+            return filtered != null ? filtered : instance;
         }
 
         private static void applyRulesForNestedObjects(

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidatorTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidatorTest.java
@@ -143,6 +143,43 @@ class ConfigurationJsonSchemaValidatorTest {
     }
 
     @Test
+    void validatesMicronautSqlDatasourceConfigurationFromPublishedRelease() {
+        Environment environment = createEnvironment(Map.of(
+            "datasources.default.driver-class-name", "org.h2.Driver",
+            "datasources.default.url", "jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE",
+            "datasources.default.username", "sa",
+            "datasources.default.password", ""
+        ));
+
+        ConfigurationJsonSchemaValidator validator = new ConfigurationJsonSchemaValidator();
+        validator.setFailOnNotPresent(true);
+
+        Set<ConfigurationError> errors = validator.validate(getClass().getClassLoader(), environment);
+
+        assertFalse(errors.stream().anyMatch(e -> e.property().startsWith("datasources.default") && e.message().contains("not present")),
+            () -> "Unexpected datasource unknown-key validation error(s): " + errors);
+    }
+
+    @Test
+    void validatesIssue316ApplicationPropertiesSnippetWithDataJdbcFixture() {
+        Environment environment = createEnvironment(Map.of(
+            "datasources.default.dialect", "H2",
+            "datasources.default.driver-class-name", "org.h2.Driver",
+            "datasources.default.url", "jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE",
+            "datasources.default.username", "sa",
+            "datasources.default.password", ""
+        ));
+
+        ConfigurationJsonSchemaValidator validator = new ConfigurationJsonSchemaValidator();
+        validator.setFailOnNotPresent(true);
+
+        Set<ConfigurationError> errors = validator.validate(getClass().getClassLoader(), environment);
+
+        assertFalse(errors.stream().anyMatch(e -> e.property().startsWith("datasources.default") && e.message().contains("not present")),
+            () -> "Unexpected datasource unknown-key validation error(s): " + errors);
+    }
+
+    @Test
     void validatesAdditionalPropertiesSchemaEvenWhenFailOnNotPresentIsFalse() {
         Environment environment = createEnvironment(Map.of(
             "test.executors.alpha.n-threads", "0"

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidatorTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidatorTest.java
@@ -156,8 +156,7 @@ class ConfigurationJsonSchemaValidatorTest {
 
         Set<ConfigurationError> errors = validator.validate(getClass().getClassLoader(), environment);
 
-        assertFalse(errors.stream().anyMatch(e -> e.property().startsWith("datasources.default") && e.message().contains("not present")),
-            () -> "Unexpected datasource unknown-key validation error(s): " + errors);
+        assertTrue(errors.isEmpty(), () -> "Expected no errors, got: " + errors);
     }
 
     @Test
@@ -175,8 +174,7 @@ class ConfigurationJsonSchemaValidatorTest {
 
         Set<ConfigurationError> errors = validator.validate(getClass().getClassLoader(), environment);
 
-        assertFalse(errors.stream().anyMatch(e -> e.property().startsWith("datasources.default") && e.message().contains("not present")),
-            () -> "Unexpected datasource unknown-key validation error(s): " + errors);
+        assertTrue(errors.isEmpty(), () -> "Expected no errors, got: " + errors);
     }
 
     @Test

--- a/json-schema-configuration-validator/src/test/resources/META-INF/micronaut-configuration-schemas/io.micronaut.data.jdbc.config.DataJdbcConfiguration.json
+++ b/json-schema-configuration-validator/src/test/resources/META-INF/micronaut-configuration-schemas/io.micronaut.data.jdbc.config.DataJdbcConfiguration.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:micronaut:config:io.micronaut.data.jdbc.config.DataJdbcConfiguration",
+  "title": "io.micronaut.data.jdbc.config.DataJdbcConfiguration",
+  "x-micronaut": {
+    "prefix": "datasources",
+    "type": "io.micronaut.data.jdbc.config.DataJdbcConfiguration",
+    "kind": "each-property",
+    "container": "map"
+  },
+  "type": "object",
+  "additionalProperties": {
+    "$ref": "#/$defs/Entry"
+  },
+  "$defs": {
+    "Entry": {
+      "type": "object",
+      "properties": {
+        "dialect": {
+          "type": "string",
+          "enum": [
+            "H2",
+            "MYSQL",
+            "POSTGRES",
+            "SQL_SERVER",
+            "ORACLE",
+            "ANSI"
+          ],
+          "x-micronaut-path": "datasources.*.dialect"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Fix unknown-property validation for prefixes shared by multiple `each-property` map schemas by merging peer entry keys before unknown-key checks.
- Add regressions for issue #316, including the exact `application.properties` datasource snippet with `datasources.default.dialect` via an isolated test schema fixture.
- Replace hardcoded Micronaut SQL test dependency with a version-catalog alias and type-safe reference.

## Verification
- `./gradlew :micronaut-json-schema-configuration-validator:test --tests 'io.micronaut.jsonschema.configuration.validator.ConfigurationJsonSchemaValidatorTest.validatesMicronautSqlDatasourceConfigurationFromPublishedRelease' --tests 'io.micronaut.jsonschema.configuration.validator.ConfigurationJsonSchemaValidatorTest.validatesIssue316ApplicationPropertiesSnippetWithDataJdbcFixture'`
- `./gradlew :micronaut-json-schema-configuration-validator:test`