### PR TITLE
Ensure default datasource suppressions apply in all validator paths

### DIFF
--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidator.java
@@ -50,7 +50,7 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
 
     private final AtomicReference<JsonMapper> jsonMapper = new AtomicReference<>();
     private boolean failOnNotPresent = true;
-    private final AtomicReference<List<String>> suppressionPatterns = new AtomicReference<>(List.of());
+    private final AtomicReference<List<String>> suppressionPatterns = new AtomicReference<>(ConfigurationValidatorConfiguration.DEFAULT_SUPPRESSIONS);
 
     /**
      * @return Whether to fail when configuration contains keys not present in schema.
@@ -89,7 +89,11 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
      * @param suppressionPatterns The suppression patterns
      */
     public void setSuppressionPatterns(@Nullable List<String> suppressionPatterns) {
-        this.suppressionPatterns.set(suppressionPatterns != null ? List.copyOf(suppressionPatterns) : List.of());
+        LinkedHashSet<String> merged = new LinkedHashSet<>(ConfigurationValidatorConfiguration.DEFAULT_SUPPRESSIONS);
+        if (suppressionPatterns != null) {
+            merged.addAll(suppressionPatterns);
+        }
+        this.suppressionPatterns.set(List.copyOf(merged));
     }
 
     /**

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationValidatorConfiguration.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationValidatorConfiguration.java
@@ -52,7 +52,10 @@ public final class ConfigurationValidatorConfiguration {
     public static final boolean DEFAULT_CACHE = true;
     public static final boolean DEFAULT_FAIL_ON_NOT_PRESENT = true;
     public static final DependencyInjectionValidationStrategy DEFAULT_DI_VALIDATION_STRATEGY = DependencyInjectionValidationStrategy.REACHABLE;
-    public static final List<String> DEFAULT_SUPPRESSIONS = List.of("datasources.*.db-type");
+    public static final List<String> DEFAULT_SUPPRESSIONS = List.of(
+        "datasources.*.db-type",
+        "datasources.*.x-protocol-url"
+    );
     private boolean cache = DEFAULT_CACHE;
     private boolean failOnNotPresent = DEFAULT_FAIL_ON_NOT_PRESENT;
     private List<String> suppressions = DEFAULT_SUPPRESSIONS;

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidatorTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidatorTest.java
@@ -49,6 +49,23 @@ class ConfigurationJsonSchemaValidatorTest {
     }
 
     @Test
+    void validatorIncludesDefaultSuppressionsByDefaultAndWhenCustomizing() {
+        ConfigurationJsonSchemaValidator validator = new ConfigurationJsonSchemaValidator();
+
+        assertTrue(validator.getSuppressionPatterns().contains("datasources.*.db-type"));
+        assertTrue(validator.getSuppressionPatterns().contains("datasources.*.x-protocol-url"));
+
+        validator.setSuppressionPatterns(List.of("micronaut.http.*"));
+        assertTrue(validator.getSuppressionPatterns().contains("datasources.*.db-type"));
+        assertTrue(validator.getSuppressionPatterns().contains("datasources.*.x-protocol-url"));
+        assertTrue(validator.getSuppressionPatterns().contains("micronaut.http.*"));
+
+        validator.setSuppressionPatterns(List.of());
+        assertTrue(validator.getSuppressionPatterns().contains("datasources.*.db-type"));
+        assertTrue(validator.getSuppressionPatterns().contains("datasources.*.x-protocol-url"));
+    }
+
+    @Test
     void doesNotReportMissingRequiredForPropertiesWithSchemaDefault() {
         Environment environment = createEnvironment(Map.of(
             "test.bindable.enabled", StringUtils.TRUE

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliTest.java
@@ -52,6 +52,7 @@ class ConfigurationJsonSchemaValidatorCliTest {
         System.clearProperty("micronaut.environments");
         System.clearProperty("spec.name");
         System.clearProperty("datasources.default.db-type");
+        System.clearProperty("datasources.default.x-protocol-url");
     }
 
     @Test
@@ -112,6 +113,7 @@ class ConfigurationJsonSchemaValidatorCliTest {
 
         assertFalse(options.deduceEnvironments());
         assertTrue(options.suppressions().contains("datasources.*.db-type"));
+        assertTrue(options.suppressions().contains("datasources.*.x-protocol-url"));
         assertTrue(options.suppressedInjectionErrors().contains("io.micronaut.security.oauth2.proxy.WellKnownProxyFilter*"));
     }
 
@@ -167,8 +169,9 @@ class ConfigurationJsonSchemaValidatorCliTest {
     }
 
     @Test
-    void datasourceDbTypeIsSuppressedByDefault() throws Exception {
+    void datasourcePropertiesAreSuppressedByDefault() throws Exception {
         System.setProperty("datasources.default.db-type", "postgres");
+        System.setProperty("datasources.default.x-protocol-url", "${auto.test.resources.datasources.default.x-protocol-url}");
 
         Path out = tempDir.resolve("out-datasource-db-type-default-suppress");
         int exit = ConfigurationJsonSchemaValidatorCli.run(new String[] {
@@ -193,6 +196,13 @@ class ConfigurationJsonSchemaValidatorCliTest {
             () -> "Expected datasource db-type to be downgraded to WARNING, got: " + list);
         assertFalse(list.stream().anyMatch(m -> "datasources.default.db-type".equals(m.get("property")) && "ERROR".equals(m.get("type"))),
             () -> "Expected datasource db-type not to remain ERROR, got: " + list);
+
+        assertTrue(list.stream().anyMatch(m -> "datasources.default.x-protocol-url".equals(m.get("property"))),
+            () -> "Expected suppressed datasource x-protocol-url entry, got: " + list);
+        assertTrue(list.stream().anyMatch(m -> "datasources.default.x-protocol-url".equals(m.get("property")) && "WARNING".equals(m.get("type"))),
+            () -> "Expected datasource x-protocol-url to be downgraded to WARNING, got: " + list);
+        assertFalse(list.stream().anyMatch(m -> "datasources.default.x-protocol-url".equals(m.get("property")) && "ERROR".equals(m.get("type"))),
+            () -> "Expected datasource x-protocol-url not to remain ERROR, got: " + list);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- move suppression defaults into `ConfigurationJsonSchemaValidator` so direct instantiation, DI factory wiring, and CLI all consistently include default patterns
- extend default suppressions to include `datasources.*.x-protocol-url` alongside `datasources.*.db-type`
- add/update validator and CLI tests to verify both datasource keys are downgraded to warnings by default and defaults remain present when custom suppressions are set

## Verification
- `./gradlew -q :micronaut-json-schema-configuration-validator:compileTestJava`
- `./gradlew :micronaut-json-schema-configuration-validator:test --tests 'io.micronaut.jsonschema.configuration.validator.ConfigurationJsonSchemaValidatorTest' --tests 'io.micronaut.jsonschema.configuration.validator.cli.ConfigurationJsonSchemaValidatorCliTest'`
- `./gradlew :micronaut-json-schema-configuration-validator:test`
- `./gradlew :micronaut-json-schema-configuration-validator:build`