### PR TITLE
Add regression coverage for DI validation issue #322

### DIFF
--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionConfigurationValidatorConfigurerTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/DependencyInjectionConfigurationValidatorConfigurerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.jsonschema.configuration.validator.cli.DependencyInjectionConfigurationValidator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DependencyInjectionConfigurationValidatorConfigurerTest {
+
+    @AfterEach
+    void cleanup() {
+        System.clearProperty(TestDependencyInjectionApplicationContextConfigurer.ENABLED_PROP);
+        TestDependencyInjectionApplicationContextConfigurer.INVOKED.set(false);
+    }
+
+    @Test
+    void applicationContextConfigurersAreApplied() {
+        DependencyInjectionConfigurationValidator facade = DependencyInjectionConfigurationValidator.forClasspath(
+            System.getProperty("java.class.path"),
+            List.of(),
+            false
+        );
+
+        Set<DependencyInjectionError> baseline = facade.validate();
+        assertTrue(baseline.stream().noneMatch(e -> e.rootBean().contains("FixtureContextBean")),
+            () -> "Unexpected baseline DI errors: " + baseline);
+
+        System.setProperty(TestDependencyInjectionApplicationContextConfigurer.ENABLED_PROP, "true");
+
+        Set<DependencyInjectionError> errors = facade.validate();
+
+        assertTrue(TestDependencyInjectionApplicationContextConfigurer.INVOKED.get(), "Expected ApplicationContextConfigurer to be invoked");
+        assertFalse(errors.isEmpty(), "Expected DI validation errors after configurer activated the test environment");
+        assertTrue(errors.stream().anyMatch(e -> e.rootBean().contains("FixtureContextBean")),
+            () -> "Expected FixtureContextBean DI error after configurer activation, got: " + errors);
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/TestDependencyInjectionApplicationContextConfigurer.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/TestDependencyInjectionApplicationContextConfigurer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jsonschema.configuration.validator;
+
+import io.micronaut.context.ApplicationContextBuilder;
+import io.micronaut.context.ApplicationContextConfigurer;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Test-only {@link ApplicationContextConfigurer} used to verify DI validation uses configurers
+ * while building metadata-only application contexts from a supplied runtime classpath.
+ */
+public final class TestDependencyInjectionApplicationContextConfigurer implements ApplicationContextConfigurer {
+
+    public static final String ENABLED_PROP = "jsonschema.test.di.appctx.configurer.enabled";
+    public static final AtomicBoolean INVOKED = new AtomicBoolean(false);
+
+    @Override
+    public void configure(ApplicationContextBuilder builder) {
+        if (!Boolean.getBoolean(ENABLED_PROP)) {
+            return;
+        }
+        INVOKED.set(true);
+        builder.environments("di-validator-test");
+    }
+}

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliTest.java
@@ -18,6 +18,7 @@ package io.micronaut.jsonschema.configuration.validator.cli;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.json.JsonMapper;
 import io.micronaut.core.type.Argument;
+import io.micronaut.jsonschema.configuration.validator.TestDependencyInjectionApplicationContextConfigurer;
 import io.micronaut.jsonschema.configuration.validator.DependencyInjectionValidationStrategy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -53,6 +54,8 @@ class ConfigurationJsonSchemaValidatorCliTest {
         System.clearProperty("spec.name");
         System.clearProperty("datasources.default.db-type");
         System.clearProperty("datasources.default.x-protocol-url");
+        System.clearProperty(TestDependencyInjectionApplicationContextConfigurer.ENABLED_PROP);
+        TestDependencyInjectionApplicationContextConfigurer.INVOKED.set(false);
     }
 
     @Test
@@ -271,6 +274,37 @@ class ConfigurationJsonSchemaValidatorCliTest {
             return value.contains("io.micronaut.context.env.Environment")
                 || value.contains("io.micronaut.core.value.PropertyResolver");
         }), () -> "Implicit infrastructure beans should be excluded from DI errors, got: " + diErrors);
+    }
+
+    @Test
+    void dependencyInjectionValidationUsesApplicationContextConfigurersAndWritesReports() throws Exception {
+        System.setProperty(TestDependencyInjectionApplicationContextConfigurer.ENABLED_PROP, StringUtils.TRUE);
+
+        Path out = tempDir.resolve("out-di-configurer");
+        ByteArrayOutputStream errCapture = new ByteArrayOutputStream();
+
+        int exit = ConfigurationJsonSchemaValidatorCli.run(new String[] {
+            "--classpath", System.getProperty("java.class.path"),
+            "--out", out.toString(),
+            "--validate-dependency-injection",
+            "--format", "json"
+        }, System.out, new PrintStream(errCapture, true, StandardCharsets.UTF_8));
+
+        assertEquals(1, exit);
+        assertTrue(TestDependencyInjectionApplicationContextConfigurer.INVOKED.get(), "Expected DI ApplicationContextConfigurer to be invoked");
+        assertTrue(Files.exists(out.resolve("configuration-errors.json")));
+
+        List<Map<String, Object>> diErrors = readDependencyInjectionErrors(out);
+        assertFalse(diErrors.isEmpty(), () -> "Expected DI errors after configurer activated the test environment, got: " + diErrors);
+        assertTrue(diErrors.stream().anyMatch(e -> String.valueOf(e.get("injectionPoint")).contains("FixtureContextBean")),
+            () -> "Expected FixtureContextBean DI error after configurer activation, got: " + diErrors);
+
+        String stderr = errCapture.toString(StandardCharsets.UTF_8);
+        assertTrue(stderr.contains("report:"), () -> "Expected report path in stderr, got:\n" + stderr);
+        assertFalse(stderr.contains("Dependency injection validation failed while loading configuration"),
+            () -> "Did not expect fatal DI loading failure, got:\n" + stderr);
+        assertFalse(stderr.contains("Cannot resolve beans until the context is running"),
+            () -> "Did not expect non-running context failure, got:\n" + stderr);
     }
 
     @Test

--- a/json-schema-configuration-validator/src/test/resources/META-INF/services/io.micronaut.context.ApplicationContextConfigurer
+++ b/json-schema-configuration-validator/src/test/resources/META-INF/services/io.micronaut.context.ApplicationContextConfigurer
@@ -1,1 +1,2 @@
 io.micronaut.jsonschema.configuration.validator.TestApplicationContextConfigurer
+io.micronaut.jsonschema.configuration.validator.TestDependencyInjectionApplicationContextConfigurer


### PR DESCRIPTION
## Summary
- add a test-only ApplicationContextConfigurer for the DI validator path
- verify DependencyInjectionConfigurationValidator applies configurers when building metadata-only contexts
- verify the CLI generates reports instead of failing with "Cannot resolve beans until the context is running"

## Verification
- ./gradlew :micronaut-json-schema-configuration-validator:test --tests '*DependencyInjectionConfigurationValidatorConfigurerTest' --tests '*ConfigurationJsonSchemaValidatorCliTest.dependencyInjectionValidationUsesApplicationContextConfigurersAndWritesReports'\n- ./gradlew :micronaut-json-schema-configuration-validator:test --tests '*JsonSchemaConfigurationValidatorConfigurerTest' --tests '*DependencyInjectionConfigurationValidatorConfigurerTest' --tests '*DependencyInjectionValidatorTest' --tests '*ConfigurationJsonSchemaValidatorCliTest'\n- sample app from issue #322: ./gradlew configurationValidationReport --stacktrace\n\nResolves #322