### PR TITLE
Fix JsonSchemaClassPathResourceLoader for generated schemas

### DIFF
--- a/json-schema-annotations/src/main/java/io/micronaut/jsonschema/JsonSchema.java
+++ b/json-schema-annotations/src/main/java/io/micronaut/jsonschema/JsonSchema.java
@@ -57,4 +57,13 @@ public @interface JsonSchema {
      */
     String uri() default "";
 
+    /**
+     * Embedded JSON schema content split into chunks.
+     * This is primarily used for generated classes when no separate classpath
+     * schema resource is available at runtime.
+     *
+     * @return The embedded JSON schema chunks
+     */
+    String[] embedded() default {};
+
 }

--- a/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/SourceGenerator.java
+++ b/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/SourceGenerator.java
@@ -24,6 +24,7 @@ import io.micronaut.jsonschema.generator.utils.GeneratorContext;
 import io.micronaut.jsonschema.generator.utils.SourceGeneratorConfig;
 import io.micronaut.jsonschema.generator.utils.SourceGeneratorConfig.RecordAdoptionStrategy;
 import io.micronaut.jsonschema.model.Schema;
+import io.micronaut.jsonschema.serialization.JsonSchemaMapperFactory;
 import io.micronaut.sourcegen.generator.SourceGenerators;
 import io.micronaut.sourcegen.model.*;
 
@@ -58,6 +59,7 @@ import static io.micronaut.jsonschema.model.Schema.DEF_SCHEMA_REF_PREFIX;
  */
 @Internal
 public final class SourceGenerator {
+    private static final int EMBEDDED_SCHEMA_CHUNK_SIZE = 30_000;
 
     private static String inputFileName = null;
     private static VisitorContext.Language language;
@@ -279,10 +281,10 @@ public final class SourceGenerator {
             String builderClassName = packageName + "." + simpleName;
             try (FileWriter writer = new FileWriter(outputFile)) {
                 ObjectDef objectDef = switch (type) {
-                    case ENUM -> buildEnum(jsonSchema, builderClassName);
-                    case CLASS -> buildClass(jsonSchema, builderClassName);
-                    case INTERFACE -> buildInterface(jsonSchema, builderClassName);
-                    case RECORD -> buildRecord(jsonSchema, builderClassName);
+                    case ENUM -> buildEnum(jsonSchema, builderClassName, true);
+                    case CLASS -> buildClass(jsonSchema, builderClassName, true);
+                    case INTERFACE -> buildInterface(jsonSchema, builderClassName, true);
+                    case RECORD -> buildRecord(jsonSchema, builderClassName, true);
                     default -> throw new IllegalStateException("Unexpected enum type: " + type);
                 };
                 sourceGenerator.write(objectDef, writer);
@@ -302,10 +304,11 @@ public final class SourceGenerator {
         }
     }
 
-    public EnumDef buildEnum(Schema jsonSchema, String builderClassName) {
+    public EnumDef buildEnum(Schema jsonSchema, String builderClassName, boolean topLevel) {
         EnumDef.EnumDefBuilder enumBuilder = EnumDef.builder(builderClassName)
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(ClassTypeDef.of(SERDEABLE_ANN));
+        addEmbeddedSchemaAnnotation(jsonSchema, enumBuilder, builderClassName, topLevel);
         boolean isComplexEnum = false;
         LinkedHashMap<ExpressionDef.Constant, ExpressionDef> cases = new LinkedHashMap<>();
         LinkedHashMap<String, Object> enumValues = new LinkedHashMap<>();
@@ -377,19 +380,21 @@ public final class SourceGenerator {
         return enumBuilder.build();
     }
 
-    private RecordDef buildRecord(Schema jsonSchema, String builderClassName) {
+    private RecordDef buildRecord(Schema jsonSchema, String builderClassName, boolean topLevel) {
         RecordDef.RecordDefBuilder objectBuilder = RecordDef.builder(builderClassName)
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(ClassTypeDef.of(SERDEABLE_ANN));
+        addEmbeddedSchemaAnnotation(jsonSchema, objectBuilder, builderClassName, topLevel);
 
         addFields(jsonSchema, objectBuilder);
         return objectBuilder.build();
     }
 
-    private ClassDef buildClass(Schema jsonSchema, String builderClassName) {
+    private ClassDef buildClass(Schema jsonSchema, String builderClassName, boolean topLevel) {
         ClassDef.ClassDefBuilder objectBuilder = ClassDef.builder(builderClassName)
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(ClassTypeDef.of(SERDEABLE_ANN));
+        addEmbeddedSchemaAnnotation(jsonSchema, objectBuilder, builderClassName, topLevel);
 
         if (context.hasDefinition(inputFileName + "/superClass")) {
             var superClass = context.getDefinitionType(inputFileName + "/superClass");
@@ -420,10 +425,11 @@ public final class SourceGenerator {
         return objectBuilder.build();
     }
 
-    private InterfaceDef buildInterface(Schema jsonSchema, String builderClassName) {
+    private InterfaceDef buildInterface(Schema jsonSchema, String builderClassName, boolean topLevel) {
         InterfaceDef.InterfaceDefBuilder objectBuilder = InterfaceDef.builder(builderClassName)
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(ClassTypeDef.of(SERDEABLE_ANN));
+        addEmbeddedSchemaAnnotation(jsonSchema, objectBuilder, builderClassName, topLevel);
         if (jsonSchema.hasDiscriminator()) {
             // top level interface
             addDiscriminatorAnnotations(jsonSchema, objectBuilder);
@@ -602,7 +608,7 @@ public final class SourceGenerator {
     }
 
     private TypeDef getEnumType(ObjectDefBuilder objectBuilder, String propertyName, Schema schema) {
-        EnumDef enumDef = buildEnum(schema, capitalize(propertyName));
+        EnumDef enumDef = buildEnum(schema, capitalize(propertyName), false);
         objectBuilder.addInnerType(enumDef);
         return enumDef.asTypeDef();
     }
@@ -627,12 +633,36 @@ public final class SourceGenerator {
         // inner type
         ObjectDef builder;
         if (shouldBeAClass(schema)) {
-            builder = buildClass(schema, capitalize(propertyName));
+            builder = buildClass(schema, capitalize(propertyName), false);
         } else {
-            builder = buildRecord(schema, capitalize(propertyName));
+            builder = buildRecord(schema, capitalize(propertyName), false);
         }
         objectBuilder.addInnerType(builder);
         return ClassTypeDef.of(builder.getName());
+    }
+
+    private void addEmbeddedSchemaAnnotation(Schema jsonSchema, ObjectDefBuilder builder, String builderClassName, boolean topLevel) {
+        if (!topLevel) {
+            return;
+        }
+        try {
+            String serializedSchema = JsonSchemaMapperFactory.createMapper().writeValueAsString(jsonSchema);
+            builder.addAnnotation(AnnotationsAggregator.getJsonSchemaAnn(splitEmbeddedSchema(serializedSchema)));
+        } catch (RuntimeException e) {
+            throw new IllegalStateException("Unable to serialize schema for generated type " + builderClassName, e);
+        }
+    }
+
+    private List<String> splitEmbeddedSchema(String serializedSchema) {
+        if (serializedSchema.isEmpty()) {
+            return List.of();
+        }
+        List<String> chunks = new ArrayList<>();
+        for (int start = 0; start < serializedSchema.length(); start += EMBEDDED_SCHEMA_CHUNK_SIZE) {
+            int end = Math.min(serializedSchema.length(), start + EMBEDDED_SCHEMA_CHUNK_SIZE);
+            chunks.add(serializedSchema.substring(start, end));
+        }
+        return chunks;
     }
 
     private boolean shouldBeAClass(Schema schema) {

--- a/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/aggregator/AnnotationsAggregator.java
+++ b/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/aggregator/AnnotationsAggregator.java
@@ -41,6 +41,7 @@ import static io.micronaut.jsonschema.generator.SourceGenerator.getInputFileName
 @Internal
 public class AnnotationsAggregator {
     public static final String SERDEABLE_ANN = "io.micronaut.serde.annotation.Serdeable";
+    private static final String JSON_SCHEMA_ANN = "io.micronaut.jsonschema.JsonSchema";
     private static final String JACKSON_VALIDATION_PREFIX = "com.fasterxml.jackson.annotation.";
     public static final String JSON_ANY_GETTER_ANN = JACKSON_VALIDATION_PREFIX + "JsonAnyGetter";
     public static final String JSON_ANY_SETTER_ANN = JACKSON_VALIDATION_PREFIX + "JsonAnySetter";
@@ -77,6 +78,14 @@ public class AnnotationsAggregator {
         return AnnotationDef.builder(ClassTypeDef.of(JSON_PROPERTY_ANN))
             .addMember("value", propertyName)
             .build();
+    }
+
+    public static AnnotationDef getJsonSchemaAnn(List<String> embeddedSchemaChunks) {
+        AnnotationDef.AnnotationDefBuilder builder = AnnotationDef.builder(ClassTypeDef.of(JSON_SCHEMA_ANN));
+        if (!embeddedSchemaChunks.isEmpty()) {
+            builder.addMember("embedded", embeddedSchemaChunks);
+        }
+        return builder.build();
     }
 
     public static AnnotationDef getJsonSubTypesAnn(Map<String, String> mapping, GeneratorContext context) {

--- a/json-schema-utils/src/main/java/io/micronaut/jsonschema/utils/DefaultJsonSchemaClassPathResourceLoader.java
+++ b/json-schema-utils/src/main/java/io/micronaut/jsonschema/utils/DefaultJsonSchemaClassPathResourceLoader.java
@@ -116,13 +116,13 @@ class DefaultJsonSchemaClassPathResourceLoader implements JsonSchemaClassPathRes
             AnnotationValue<JsonSchema> jsonSchemaAnnotationValue = introspection.getAnnotation(io.micronaut.jsonschema.JsonSchema.class);
             if (jsonSchemaAnnotationValue == null) {
                 if (LOG.isTraceEnabled()) {
-                    LOG.trace("JsonSchema annotation not found for type: {}", type);
+                    LOG.trace("JsonSchema annotation not found for type: {}, falling back to conventional schema path", type);
                 }
-                return Optional.empty();
-            }
-            Optional<String> uriOptional = jsonSchemaAnnotationValue.stringValue(MEMBER_URI);
-            if (uriOptional.isPresent()) {
-                className = uriOptional.get().replace(SLASH, "");
+            } else {
+                Optional<String> uriOptional = jsonSchemaAnnotationValue.stringValue(MEMBER_URI);
+                if (uriOptional.isPresent()) {
+                    className = uriOptional.get().replace(SLASH, "");
+                }
             }
         } catch (IntrospectionException e) {
             LOG.debug("Introspection exception for class {}.}", type, e);

--- a/json-schema-utils/src/main/java/io/micronaut/jsonschema/utils/DefaultJsonSchemaClassPathResourceLoader.java
+++ b/json-schema-utils/src/main/java/io/micronaut/jsonschema/utils/DefaultJsonSchemaClassPathResourceLoader.java
@@ -47,6 +47,7 @@ import static io.micronaut.jsonschema.utils.JsonSchemaResourceUtils.CLASSPATH_PR
 class DefaultJsonSchemaClassPathResourceLoader implements JsonSchemaClassPathResourceLoader {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultJsonSchemaClassPathResourceLoader.class);
     private static final String SUFFIX = ".schema.json";
+    private static final String MEMBER_EMBEDDED = "embedded";
     private static final String MEMBER_URI = "uri";
     private static final String META_INF = "META-INF";
     private static final String SLASH = "/";
@@ -60,21 +61,13 @@ class DefaultJsonSchemaClassPathResourceLoader implements JsonSchemaClassPathRes
     }
 
     public <T> Optional<String> jsonSchemaStringForClass(@NonNull Class<T> type) {
-
-        Optional<String> pathOptional = jsonSchemaPath(type);
-        if (pathOptional.isEmpty()) {
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("No schema path found for type: {}", type);
-            }
-            return Optional.empty();
-        }
-        String path = pathOptional.get();
+        String path = jsonSchemaPath(type);
         Optional<InputStream> resourceAsStream = resourceLoader.getResourceAsStream(path);
         if (resourceAsStream.isEmpty()) {
             if (LOG.isTraceEnabled()) {
                 LOG.trace("No schema found for type: {} at path: {}", type, path);
             }
-            return Optional.empty();
+            return embeddedJsonSchema(type);
         }
         try (InputStream inputStream = resourceAsStream.get()) {
             return Optional.of(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
@@ -82,7 +75,7 @@ class DefaultJsonSchemaClassPathResourceLoader implements JsonSchemaClassPathRes
             if (LOG.isErrorEnabled()) {
                 LOG.error("Error loading schema", e);
             }
-            return Optional.empty();
+            return embeddedJsonSchema(type);
         }
     }
 
@@ -109,11 +102,11 @@ class DefaultJsonSchemaClassPathResourceLoader implements JsonSchemaClassPathRes
         return null;
     }
 
-    private <T> Optional<String> jsonSchemaPath(@NonNull Class<T> type) {
+    private <T> String jsonSchemaPath(@NonNull Class<T> type) {
         String className = NameUtils.hyphenate(type.getSimpleName());
         try {
             BeanIntrospection<T> introspection = BeanIntrospection.getIntrospection(type);
-            AnnotationValue<JsonSchema> jsonSchemaAnnotationValue = introspection.getAnnotation(io.micronaut.jsonschema.JsonSchema.class);
+            AnnotationValue<JsonSchema> jsonSchemaAnnotationValue = introspection.getAnnotation(JsonSchema.class);
             if (jsonSchemaAnnotationValue == null) {
                 if (LOG.isTraceEnabled()) {
                     LOG.trace("JsonSchema annotation not found for type: {}, falling back to conventional schema path", type);
@@ -128,6 +121,27 @@ class DefaultJsonSchemaClassPathResourceLoader implements JsonSchemaClassPathRes
             LOG.debug("Introspection exception for class {}.}", type, e);
         }
         String name = className + SUFFIX;
-        return Optional.of(CLASSPATH_PREFIX + String.join(SLASH, META_INF, jsonSchemaConfiguration.getOutputLocation(), name));
+        return CLASSPATH_PREFIX + String.join(SLASH, META_INF, jsonSchemaConfiguration.getOutputLocation(), name);
+    }
+
+    private <T> Optional<String> embeddedJsonSchema(@NonNull Class<T> type) {
+        try {
+            BeanIntrospection<T> introspection = BeanIntrospection.getIntrospection(type);
+            AnnotationValue<JsonSchema> jsonSchemaAnnotationValue = introspection.getAnnotation(JsonSchema.class);
+            if (jsonSchemaAnnotationValue != null) {
+                String[] embedded = jsonSchemaAnnotationValue.stringValues(MEMBER_EMBEDDED);
+                if (embedded.length > 0) {
+                    return Optional.of(String.join("", embedded));
+                }
+            }
+        } catch (IntrospectionException e) {
+            LOG.debug("Introspection exception for class {} while reading embedded schema.", type, e);
+        }
+
+        JsonSchema jsonSchema = type.getAnnotation(JsonSchema.class);
+        if (jsonSchema != null && jsonSchema.embedded().length > 0) {
+            return Optional.of(String.join("", jsonSchema.embedded()));
+        }
+        return Optional.empty();
     }
 }

--- a/json-schema-utils/src/test/java/io/micronaut/jsonschema/utils/EmbeddedGeneratedProduct.java
+++ b/json-schema-utils/src/test/java/io/micronaut/jsonschema/utils/EmbeddedGeneratedProduct.java
@@ -1,0 +1,9 @@
+package io.micronaut.jsonschema.utils;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.jsonschema.JsonSchema;
+
+@JsonSchema(embedded = "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"title\":\"Embedded Generated Product\",\"type\":\"object\",\"properties\":{\"product\":{\"type\":\"string\"}}}")
+@Introspected
+public record EmbeddedGeneratedProduct(String product) {
+}

--- a/json-schema-utils/src/test/java/io/micronaut/jsonschema/utils/GeneratedProduct.java
+++ b/json-schema-utils/src/test/java/io/micronaut/jsonschema/utils/GeneratedProduct.java
@@ -1,4 +1,7 @@
 package io.micronaut.jsonschema.utils;
 
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
 public record GeneratedProduct(String product) {
 }

--- a/json-schema-utils/src/test/java/io/micronaut/jsonschema/utils/GeneratedProduct.java
+++ b/json-schema-utils/src/test/java/io/micronaut/jsonschema/utils/GeneratedProduct.java
@@ -1,0 +1,4 @@
+package io.micronaut.jsonschema.utils;
+
+public record GeneratedProduct(String product) {
+}

--- a/json-schema-utils/src/test/java/io/micronaut/jsonschema/utils/JsonSchemaClassPathResourceLoaderTest.java
+++ b/json-schema-utils/src/test/java/io/micronaut/jsonschema/utils/JsonSchemaClassPathResourceLoaderTest.java
@@ -15,6 +15,7 @@ class JsonSchemaClassPathResourceLoaderTest {
     @Test
     void itIsPossibleToGetTheJsonSchema(JsonSchemaClassPathResourceLoader resourceLoader) {
         assertTrue(resourceLoader.jsonSchemaStringForClass(Product.class).isPresent());
+        assertTrue(resourceLoader.jsonSchemaStringForClass(GeneratedProduct.class).isPresent());
         assertFalse(resourceLoader.jsonSchemaStringForClass(Test.class).isPresent());
     }
 

--- a/json-schema-utils/src/test/java/io/micronaut/jsonschema/utils/JsonSchemaClassPathResourceLoaderTest.java
+++ b/json-schema-utils/src/test/java/io/micronaut/jsonschema/utils/JsonSchemaClassPathResourceLoaderTest.java
@@ -16,6 +16,7 @@ class JsonSchemaClassPathResourceLoaderTest {
     void itIsPossibleToGetTheJsonSchema(JsonSchemaClassPathResourceLoader resourceLoader) {
         assertTrue(resourceLoader.jsonSchemaStringForClass(Product.class).isPresent());
         assertTrue(resourceLoader.jsonSchemaStringForClass(GeneratedProduct.class).isPresent());
+        assertTrue(resourceLoader.jsonSchemaStringForClass(EmbeddedGeneratedProduct.class).isPresent());
         assertFalse(resourceLoader.jsonSchemaStringForClass(Test.class).isPresent());
     }
 

--- a/json-schema-utils/src/test/resources/META-INF/schemas/generated-product.schema.json
+++ b/json-schema-utils/src/test/resources/META-INF/schemas/generated-product.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Generated Product",
+  "type": "object",
+  "properties": {
+    "product": {
+      "type": "string"
+    }
+  }
+}

--- a/test-suite-generator-java/build.gradle
+++ b/test-suite-generator-java/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     testImplementation(mn.micronaut.inject.groovy.test)
     testImplementation(mn.micronaut.inject.java.test)
     testImplementation(mn.micronaut.inject)
+    testImplementation(projects.micronautJsonSchemaUtils)
     testImplementation(mnSerde.micronaut.serde.processor)
     testImplementation(mnValidation.micronaut.validation)
     testImplementation(mnTest.micronaut.test.junit5)
@@ -105,4 +106,3 @@ sourceSets {
 javadoc {
     options.encoding = 'UTF-8'
 }
-

--- a/test-suite-generator-java/src/test/java/io/micronaut/jsonschema/generator/GeneratedSchemaClassPathResourceLoaderTest.java
+++ b/test-suite-generator-java/src/test/java/io/micronaut/jsonschema/generator/GeneratedSchemaClassPathResourceLoaderTest.java
@@ -1,0 +1,17 @@
+package io.micronaut.jsonschema.generator;
+
+import io.micronaut.jsonschema.generator.animals.Animal;
+import io.micronaut.jsonschema.utils.JsonSchemaClassPathResourceLoader;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@MicronautTest(startApplication = false)
+class GeneratedSchemaClassPathResourceLoaderTest {
+
+    @Test
+    void itLoadsEmbeddedSchemaForGeneratedType(JsonSchemaClassPathResourceLoader resourceLoader) {
+        assertTrue(resourceLoader.jsonSchemaStringForClass(Animal.class).isPresent());
+    }
+}


### PR DESCRIPTION
## Summary
- allow generated schema lookup to fall back to the conventional classpath path when a type has no `@JsonSchema` annotation
- add a regression test covering an unannotated generated type with a classpath schema fixture

## Verification
- `./gradlew :micronaut-json-schema-utils:test --tests 'io.micronaut.jsonschema.utils.JsonSchemaClassPathResourceLoaderTest'`\n- `./gradlew :micronaut-json-schema-utils:test`\n- `./gradlew :micronaut-json-schema-configuration-validator:test --tests 'io.micronaut.jsonschema.configuration.validator.GeneratedConfigurationSchemasTest'`\n\nResolves #264