### PR TITLE
Handle default configuration suppressions silently

### DIFF
--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidator.java
@@ -45,12 +45,15 @@ import java.util.regex.Pattern;
  */
 public final class ConfigurationJsonSchemaValidator implements ConfigurationValidator {
     private static final Argument<ConfigurationSchema> CONFIGURATION_SCHEMA_ARGUMENT = Argument.of(ConfigurationSchema.class);
+    private static final List<SuppressionMatcher> DEFAULT_SUPPRESSION_MATCHERS =
+        SuppressionMatcher.compileAll(ConfigurationValidatorConfiguration.DEFAULT_SUPPRESSIONS);
 
     private final SchemaValidationEngine engine = new SchemaValidationEngine();
 
     private final AtomicReference<JsonMapper> jsonMapper = new AtomicReference<>();
     private boolean failOnNotPresent = true;
     private final AtomicReference<List<String>> suppressionPatterns = new AtomicReference<>(ConfigurationValidatorConfiguration.DEFAULT_SUPPRESSIONS);
+    private final AtomicReference<List<String>> customSuppressionPatterns = new AtomicReference<>(List.of());
 
     /**
      * @return Whether to fail when configuration contains keys not present in schema.
@@ -74,7 +77,8 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
     }
 
     /**
-     * Patterns used to suppress validation errors. Matching errors are downgraded to warnings.
+     * Patterns used to suppress validation errors. User-provided matches are downgraded to warnings;
+     * built-in suppressions are silently ignored.
      *
      * @return The suppression patterns
      */
@@ -83,17 +87,26 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
     }
 
     /**
-     * Set patterns used to suppress validation errors. Matching errors are downgraded to warnings.
+     * Set patterns used to suppress validation errors. User-provided matches are downgraded to
+     * warnings; built-in suppressions are silently ignored.
      * Patterns may include {@code *} wildcards (for example {@code micronaut.http.*}).
      *
      * @param suppressionPatterns The suppression patterns
      */
     public void setSuppressionPatterns(@Nullable List<String> suppressionPatterns) {
         LinkedHashSet<String> merged = new LinkedHashSet<>(ConfigurationValidatorConfiguration.DEFAULT_SUPPRESSIONS);
+        LinkedHashSet<String> custom = new LinkedHashSet<>();
         if (suppressionPatterns != null) {
-            merged.addAll(suppressionPatterns);
+            for (String suppressionPattern : suppressionPatterns) {
+                if (ConfigurationValidatorConfiguration.DEFAULT_SUPPRESSIONS.contains(suppressionPattern)) {
+                    continue;
+                }
+                merged.add(suppressionPattern);
+                custom.add(suppressionPattern);
+            }
         }
         this.suppressionPatterns.set(List.copyOf(merged));
+        this.customSuppressionPatterns.set(List.copyOf(custom));
     }
 
     /**
@@ -171,23 +184,29 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
     }
 
     private Set<ConfigurationError> applySuppressions(Set<ConfigurationError> errors) {
-        List<String> patterns = suppressionPatterns.get();
-        if (patterns.isEmpty() || errors.isEmpty()) {
+        if (errors.isEmpty()) {
             return errors;
         }
 
-        List<SuppressionMatcher> matchers = SuppressionMatcher.compileAll(patterns);
-        if (matchers.isEmpty()) {
+        List<SuppressionMatcher> customMatchers = SuppressionMatcher.compileAll(customSuppressionPatterns.get());
+        if (DEFAULT_SUPPRESSION_MATCHERS.isEmpty() && customMatchers.isEmpty()) {
             return errors;
         }
 
         Set<ConfigurationError> result = new LinkedHashSet<>(errors.size());
         for (ConfigurationError error : errors) {
-            if (error.type() == ConfigurationError.Type.ERROR && matchesAny(matchers, error.property())) {
-                result.add(error.withType(ConfigurationError.Type.WARNING));
-            } else {
+            if (error.type() != ConfigurationError.Type.ERROR) {
                 result.add(error);
+                continue;
             }
+            if (matchesAny(DEFAULT_SUPPRESSION_MATCHERS, error.property())) {
+                continue;
+            }
+            if (matchesAny(customMatchers, error.property())) {
+                result.add(error.withType(ConfigurationError.Type.WARNING));
+                continue;
+            }
+            result.add(error);
         }
         return result;
     }

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationValidatorConfiguration.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationValidatorConfiguration.java
@@ -54,6 +54,7 @@ public final class ConfigurationValidatorConfiguration {
     public static final DependencyInjectionValidationStrategy DEFAULT_DI_VALIDATION_STRATEGY = DependencyInjectionValidationStrategy.REACHABLE;
     public static final List<String> DEFAULT_SUPPRESSIONS = List.of(
         "micronaut.classloader",
+        "micronaut.home",
         "micronaut.test",
         "datasources.*.db-type",
         "datasources.*.x-protocol-url"
@@ -103,7 +104,8 @@ public final class ConfigurationValidatorConfiguration {
     /**
      * Patterns used to suppress validation errors.
      * <p>
-     * Matching errors are downgraded to warnings.
+     * Matching errors are downgraded to warnings, except for built-in suppressions which are
+     * silently ignored.
      *
      * @return Patterns used to suppress validation errors
      */

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidatorTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidatorTest.java
@@ -54,15 +54,39 @@ class ConfigurationJsonSchemaValidatorTest {
 
         assertTrue(validator.getSuppressionPatterns().contains("datasources.*.db-type"));
         assertTrue(validator.getSuppressionPatterns().contains("datasources.*.x-protocol-url"));
+        assertTrue(validator.getSuppressionPatterns().contains("micronaut.home"));
 
         validator.setSuppressionPatterns(List.of("micronaut.http.*"));
         assertTrue(validator.getSuppressionPatterns().contains("datasources.*.db-type"));
         assertTrue(validator.getSuppressionPatterns().contains("datasources.*.x-protocol-url"));
+        assertTrue(validator.getSuppressionPatterns().contains("micronaut.home"));
         assertTrue(validator.getSuppressionPatterns().contains("micronaut.http.*"));
 
         validator.setSuppressionPatterns(List.of());
         assertTrue(validator.getSuppressionPatterns().contains("datasources.*.db-type"));
         assertTrue(validator.getSuppressionPatterns().contains("datasources.*.x-protocol-url"));
+        assertTrue(validator.getSuppressionPatterns().contains("micronaut.home"));
+    }
+
+    @Test
+    void defaultSuppressionsAreIgnoredInsteadOfReportedAsWarnings() {
+        Environment environment = createEnvironment(Map.of(
+            "datasources.default.db-type", "postgres",
+            "datasources.default.x-protocol-url", "jdbc:mysql://localhost/test",
+            "micronaut.home", "/tmp/micronaut"
+        ));
+
+        ConfigurationJsonSchemaValidator validator = new ConfigurationJsonSchemaValidator();
+        validator.setFailOnNotPresent(true);
+
+        Set<ConfigurationError> errors = validator.validate(getClass().getClassLoader(), environment);
+
+        assertFalse(errors.stream().anyMatch(e -> e.property().equals("datasources.default.db-type")),
+            () -> "Expected datasource db-type default suppression to be silent, got: " + errors);
+        assertFalse(errors.stream().anyMatch(e -> e.property().equals("datasources.default.x-protocol-url")),
+            () -> "Expected datasource x-protocol-url default suppression to be silent, got: " + errors);
+        assertFalse(errors.stream().anyMatch(e -> e.property().equals("micronaut.home")),
+            () -> "Expected micronaut.home default suppression to be silent, got: " + errors);
     }
 
     @Test

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliTest.java
@@ -113,6 +113,7 @@ class ConfigurationJsonSchemaValidatorCliTest {
 
         assertFalse(options.deduceEnvironments());
         assertTrue(options.suppressions().contains("micronaut.classloader"));
+        assertTrue(options.suppressions().contains("micronaut.home"));
         assertTrue(options.suppressions().contains("micronaut.test"));
         assertTrue(options.suppressions().contains("datasources.*.db-type"));
         assertTrue(options.suppressions().contains("datasources.*.x-protocol-url"));
@@ -174,37 +175,37 @@ class ConfigurationJsonSchemaValidatorCliTest {
     void datasourcePropertiesAreSuppressedByDefault() throws Exception {
         System.setProperty("datasources.default.db-type", "postgres");
         System.setProperty("datasources.default.x-protocol-url", "${auto.test.resources.datasources.default.x-protocol-url}");
+        System.setProperty("micronaut.home", "/tmp/micronaut-home");
 
         Path out = tempDir.resolve("out-datasource-db-type-default-suppress");
-        int exit = ConfigurationJsonSchemaValidatorCli.run(new String[] {
-            "--classpath", System.getProperty("java.class.path"),
-            "--environments", "test",
-            "--out", out.toString(),
-            "--format", "json"
-        }, System.out, System.err);
+        try {
+            int exit = ConfigurationJsonSchemaValidatorCli.run(new String[] {
+                "--classpath", System.getProperty("java.class.path"),
+                "--environments", "test",
+                "--out", out.toString(),
+                "--format", "json"
+            }, System.out, System.err);
 
-        assertEquals(0, exit);
+            assertEquals(0, exit);
 
-        String json = Files.readString(out.resolve("configuration-errors.json"), StandardCharsets.UTF_8);
-        Object decoded = JsonMapper.createDefault().readValue(json, Argument.of(Object.class));
-        assertNotNull(decoded);
-        assertInstanceOf(Map.class, decoded);
+            String json = Files.readString(out.resolve("configuration-errors.json"), StandardCharsets.UTF_8);
+            Object decoded = JsonMapper.createDefault().readValue(json, Argument.of(Object.class));
+            assertNotNull(decoded);
+            assertInstanceOf(Map.class, decoded);
 
-        @SuppressWarnings("unchecked")
-        List<Map<String, Object>> list = (List<Map<String, Object>>) ((Map<String, Object>) decoded).get("configurationErrors");
-        assertTrue(list.stream().anyMatch(m -> "datasources.default.db-type".equals(m.get("property"))),
-            () -> "Expected suppressed datasource db-type entry, got: " + list);
-        assertTrue(list.stream().anyMatch(m -> "datasources.default.db-type".equals(m.get("property")) && "WARNING".equals(m.get("type"))),
-            () -> "Expected datasource db-type to be downgraded to WARNING, got: " + list);
-        assertFalse(list.stream().anyMatch(m -> "datasources.default.db-type".equals(m.get("property")) && "ERROR".equals(m.get("type"))),
-            () -> "Expected datasource db-type not to remain ERROR, got: " + list);
-
-        assertTrue(list.stream().anyMatch(m -> "datasources.default.x-protocol-url".equals(m.get("property"))),
-            () -> "Expected suppressed datasource x-protocol-url entry, got: " + list);
-        assertTrue(list.stream().anyMatch(m -> "datasources.default.x-protocol-url".equals(m.get("property")) && "WARNING".equals(m.get("type"))),
-            () -> "Expected datasource x-protocol-url to be downgraded to WARNING, got: " + list);
-        assertFalse(list.stream().anyMatch(m -> "datasources.default.x-protocol-url".equals(m.get("property")) && "ERROR".equals(m.get("type"))),
-            () -> "Expected datasource x-protocol-url not to remain ERROR, got: " + list);
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> list = (List<Map<String, Object>>) ((Map<String, Object>) decoded).getOrDefault("configurationErrors", List.of());
+            assertFalse(list.stream().anyMatch(m -> "datasources.default.db-type".equals(m.get("property"))),
+                () -> "Expected datasource db-type default suppression to be silent, got: " + list);
+            assertFalse(list.stream().anyMatch(m -> "datasources.default.x-protocol-url".equals(m.get("property"))),
+                () -> "Expected datasource x-protocol-url default suppression to be silent, got: " + list);
+            assertFalse(list.stream().anyMatch(m -> "micronaut.home".equals(m.get("property"))),
+                () -> "Expected micronaut.home default suppression to be silent, got: " + list);
+        } finally {
+            System.clearProperty("datasources.default.db-type");
+            System.clearProperty("datasources.default.x-protocol-url");
+            System.clearProperty("micronaut.home");
+        }
     }
 
     @Test

--- a/src/main/docs/guide/configurationValidator.adoc
+++ b/src/main/docs/guide/configurationValidator.adoc
@@ -35,7 +35,9 @@ If a schema property is marked as deprecated (`"deprecated": true`), the validat
 
 By default unknown properties are treated as errors (and some schemas also enforce this via `additionalProperties: false`).
 
-You can downgrade matching errors to warnings by configuring suppression patterns (for example `micronaut.http.*`).
+Built-in suppression patterns silence known framework-managed properties such as `micronaut.home`.
+
+You can downgrade matching errors to warnings by configuring your own suppression patterns (for example `micronaut.http.*`).
 
 === Reports
 


### PR DESCRIPTION
## Summary
- add micronaut.home to the default configuration suppressions
- keep built-in suppressions silent instead of reporting them as warnings
- retain warning downgrades for user-provided suppression patterns and cover the change in tests/docs

## Verification
- ./gradlew :micronaut-json-schema-configuration-validator:test --tests 'io.micronaut.jsonschema.configuration.validator.ConfigurationJsonSchemaValidatorTest' --tests 'io.micronaut.jsonschema.configuration.validator.cli.ConfigurationJsonSchemaValidatorCliTest' --tests 'io.micronaut.jsonschema.configuration.validator.InvalidConfigurationSupressionsTest'