### PR TITLE
Add default test resources suppression pattern

### DIFF
--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationValidatorConfiguration.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationValidatorConfiguration.java
@@ -56,6 +56,7 @@ public final class ConfigurationValidatorConfiguration {
         "micronaut.classloader",
         "micronaut.home",
         "micronaut.test",
+        "micronaut.test-resources*",
         "datasources.*.db-type",
         "datasources.*.x-protocol-url"
     );

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidatorTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidatorTest.java
@@ -55,17 +55,20 @@ class ConfigurationJsonSchemaValidatorTest {
         assertTrue(validator.getSuppressionPatterns().contains("datasources.*.db-type"));
         assertTrue(validator.getSuppressionPatterns().contains("datasources.*.x-protocol-url"));
         assertTrue(validator.getSuppressionPatterns().contains("micronaut.home"));
+        assertTrue(validator.getSuppressionPatterns().contains("micronaut.test-resources*"));
 
         validator.setSuppressionPatterns(List.of("micronaut.http.*"));
         assertTrue(validator.getSuppressionPatterns().contains("datasources.*.db-type"));
         assertTrue(validator.getSuppressionPatterns().contains("datasources.*.x-protocol-url"));
         assertTrue(validator.getSuppressionPatterns().contains("micronaut.home"));
+        assertTrue(validator.getSuppressionPatterns().contains("micronaut.test-resources*"));
         assertTrue(validator.getSuppressionPatterns().contains("micronaut.http.*"));
 
         validator.setSuppressionPatterns(List.of());
         assertTrue(validator.getSuppressionPatterns().contains("datasources.*.db-type"));
         assertTrue(validator.getSuppressionPatterns().contains("datasources.*.x-protocol-url"));
         assertTrue(validator.getSuppressionPatterns().contains("micronaut.home"));
+        assertTrue(validator.getSuppressionPatterns().contains("micronaut.test-resources*"));
     }
 
     @Test
@@ -73,7 +76,9 @@ class ConfigurationJsonSchemaValidatorTest {
         Environment environment = createEnvironment(Map.of(
             "datasources.default.db-type", "postgres",
             "datasources.default.x-protocol-url", "jdbc:mysql://localhost/test",
-            "micronaut.home", "/tmp/micronaut"
+            "micronaut.home", "/tmp/micronaut",
+            "micronaut.test-resources", "enabled",
+            "micronaut.test-resources-server-uri", "http://localhost:8080"
         ));
 
         ConfigurationJsonSchemaValidator validator = new ConfigurationJsonSchemaValidator();
@@ -87,6 +92,10 @@ class ConfigurationJsonSchemaValidatorTest {
             () -> "Expected datasource x-protocol-url default suppression to be silent, got: " + errors);
         assertFalse(errors.stream().anyMatch(e -> e.property().equals("micronaut.home")),
             () -> "Expected micronaut.home default suppression to be silent, got: " + errors);
+        assertFalse(errors.stream().anyMatch(e -> e.property().equals("micronaut.test-resources")),
+            () -> "Expected micronaut.test-resources default suppression to be silent, got: " + errors);
+        assertFalse(errors.stream().anyMatch(e -> e.property().equals("micronaut.test-resources-server-uri")),
+            () -> "Expected micronaut.test-resources-server-uri default suppression to be silent, got: " + errors);
     }
 
     @Test

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliTest.java
@@ -179,6 +179,8 @@ class ConfigurationJsonSchemaValidatorCliTest {
         System.setProperty("datasources.default.db-type", "postgres");
         System.setProperty("datasources.default.x-protocol-url", "${auto.test.resources.datasources.default.x-protocol-url}");
         System.setProperty("micronaut.home", "/tmp/micronaut-home");
+        System.setProperty("micronaut.test-resources", "enabled");
+        System.setProperty("micronaut.test-resources-server-uri", "http://localhost:8080");
 
         Path out = tempDir.resolve("out-datasource-db-type-default-suppress");
         try {
@@ -204,10 +206,16 @@ class ConfigurationJsonSchemaValidatorCliTest {
                 () -> "Expected datasource x-protocol-url default suppression to be silent, got: " + list);
             assertFalse(list.stream().anyMatch(m -> "micronaut.home".equals(m.get("property"))),
                 () -> "Expected micronaut.home default suppression to be silent, got: " + list);
+            assertFalse(list.stream().anyMatch(m -> "micronaut.test-resources".equals(m.get("property"))),
+                () -> "Expected micronaut.test-resources default suppression to be silent, got: " + list);
+            assertFalse(list.stream().anyMatch(m -> "micronaut.test-resources-server-uri".equals(m.get("property"))),
+                () -> "Expected micronaut.test-resources-server-uri default suppression to be silent, got: " + list);
         } finally {
             System.clearProperty("datasources.default.db-type");
             System.clearProperty("datasources.default.x-protocol-url");
             System.clearProperty("micronaut.home");
+            System.clearProperty("micronaut.test-resources");
+            System.clearProperty("micronaut.test-resources-server-uri");
         }
     }
 

--- a/src/main/docs/guide/configurationValidator.adoc
+++ b/src/main/docs/guide/configurationValidator.adoc
@@ -35,7 +35,7 @@ If a schema property is marked as deprecated (`"deprecated": true`), the validat
 
 By default unknown properties are treated as errors (and some schemas also enforce this via `additionalProperties: false`).
 
-Built-in suppression patterns silence known framework-managed properties such as `micronaut.home`.
+Built-in suppression patterns silence known framework-managed properties such as `micronaut.home` and `micronaut.test-resources*`.
 
 You can downgrade matching errors to warnings by configuring your own suppression patterns (for example `micronaut.http.*`).
 


### PR DESCRIPTION
## Summary
- add `micronaut.test-resources*` to the built-in configuration validator suppressions
- extend validator and CLI tests to verify test resources properties stay silently suppressed by default
- document the new built-in suppression pattern

## Verification
- ./gradlew :micronaut-json-schema-configuration-validator:test --tests io.micronaut.jsonschema.configuration.validator.ConfigurationJsonSchemaValidatorTest --tests io.micronaut.jsonschema.configuration.validator.cli.ConfigurationJsonSchemaValidatorCliTest