### PR TITLE
Add micronaut.processing to default suppressions

### DIFF
--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationValidatorConfiguration.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationValidatorConfiguration.java
@@ -55,6 +55,7 @@ public final class ConfigurationValidatorConfiguration {
     public static final List<String> DEFAULT_SUPPRESSIONS = List.of(
         "micronaut.classloader",
         "micronaut.home",
+        "micronaut.processing",
         "micronaut.test",
         "micronaut.test-resources*",
         "datasources.*.db-type",

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidatorTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidatorTest.java
@@ -55,12 +55,14 @@ class ConfigurationJsonSchemaValidatorTest {
         assertTrue(validator.getSuppressionPatterns().contains("datasources.*.db-type"));
         assertTrue(validator.getSuppressionPatterns().contains("datasources.*.x-protocol-url"));
         assertTrue(validator.getSuppressionPatterns().contains("micronaut.home"));
+        assertTrue(validator.getSuppressionPatterns().contains("micronaut.processing"));
         assertTrue(validator.getSuppressionPatterns().contains("micronaut.test-resources*"));
 
         validator.setSuppressionPatterns(List.of("micronaut.http.*"));
         assertTrue(validator.getSuppressionPatterns().contains("datasources.*.db-type"));
         assertTrue(validator.getSuppressionPatterns().contains("datasources.*.x-protocol-url"));
         assertTrue(validator.getSuppressionPatterns().contains("micronaut.home"));
+        assertTrue(validator.getSuppressionPatterns().contains("micronaut.processing"));
         assertTrue(validator.getSuppressionPatterns().contains("micronaut.test-resources*"));
         assertTrue(validator.getSuppressionPatterns().contains("micronaut.http.*"));
 
@@ -68,6 +70,7 @@ class ConfigurationJsonSchemaValidatorTest {
         assertTrue(validator.getSuppressionPatterns().contains("datasources.*.db-type"));
         assertTrue(validator.getSuppressionPatterns().contains("datasources.*.x-protocol-url"));
         assertTrue(validator.getSuppressionPatterns().contains("micronaut.home"));
+        assertTrue(validator.getSuppressionPatterns().contains("micronaut.processing"));
         assertTrue(validator.getSuppressionPatterns().contains("micronaut.test-resources*"));
     }
 
@@ -77,6 +80,7 @@ class ConfigurationJsonSchemaValidatorTest {
             "datasources.default.db-type", "postgres",
             "datasources.default.x-protocol-url", "jdbc:mysql://localhost/test",
             "micronaut.home", "/tmp/micronaut",
+            "micronaut.processing.group", "com.example",
             "micronaut.test-resources", "enabled",
             "micronaut.test-resources-server-uri", "http://localhost:8080"
         ));
@@ -92,6 +96,8 @@ class ConfigurationJsonSchemaValidatorTest {
             () -> "Expected datasource x-protocol-url default suppression to be silent, got: " + errors);
         assertFalse(errors.stream().anyMatch(e -> e.property().equals("micronaut.home")),
             () -> "Expected micronaut.home default suppression to be silent, got: " + errors);
+        assertFalse(errors.stream().anyMatch(e -> e.property().equals("micronaut.processing")),
+            () -> "Expected micronaut.processing default suppression to be silent, got: " + errors);
         assertFalse(errors.stream().anyMatch(e -> e.property().equals("micronaut.test-resources")),
             () -> "Expected micronaut.test-resources default suppression to be silent, got: " + errors);
         assertFalse(errors.stream().anyMatch(e -> e.property().equals("micronaut.test-resources-server-uri")),

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/cli/ConfigurationJsonSchemaValidatorCliTest.java
@@ -117,6 +117,7 @@ class ConfigurationJsonSchemaValidatorCliTest {
         assertFalse(options.deduceEnvironments());
         assertTrue(options.suppressions().contains("micronaut.classloader"));
         assertTrue(options.suppressions().contains("micronaut.home"));
+        assertTrue(options.suppressions().contains("micronaut.processing"));
         assertTrue(options.suppressions().contains("micronaut.test"));
         assertTrue(options.suppressions().contains("datasources.*.db-type"));
         assertTrue(options.suppressions().contains("datasources.*.x-protocol-url"));
@@ -179,6 +180,7 @@ class ConfigurationJsonSchemaValidatorCliTest {
         System.setProperty("datasources.default.db-type", "postgres");
         System.setProperty("datasources.default.x-protocol-url", "${auto.test.resources.datasources.default.x-protocol-url}");
         System.setProperty("micronaut.home", "/tmp/micronaut-home");
+        System.setProperty("micronaut.processing.group", "com.example");
         System.setProperty("micronaut.test-resources", "enabled");
         System.setProperty("micronaut.test-resources-server-uri", "http://localhost:8080");
 
@@ -206,6 +208,8 @@ class ConfigurationJsonSchemaValidatorCliTest {
                 () -> "Expected datasource x-protocol-url default suppression to be silent, got: " + list);
             assertFalse(list.stream().anyMatch(m -> "micronaut.home".equals(m.get("property"))),
                 () -> "Expected micronaut.home default suppression to be silent, got: " + list);
+            assertFalse(list.stream().anyMatch(m -> "micronaut.processing".equals(m.get("property"))),
+                () -> "Expected micronaut.processing default suppression to be silent, got: " + list);
             assertFalse(list.stream().anyMatch(m -> "micronaut.test-resources".equals(m.get("property"))),
                 () -> "Expected micronaut.test-resources default suppression to be silent, got: " + list);
             assertFalse(list.stream().anyMatch(m -> "micronaut.test-resources-server-uri".equals(m.get("property"))),
@@ -214,6 +218,7 @@ class ConfigurationJsonSchemaValidatorCliTest {
             System.clearProperty("datasources.default.db-type");
             System.clearProperty("datasources.default.x-protocol-url");
             System.clearProperty("micronaut.home");
+            System.clearProperty("micronaut.processing.group");
             System.clearProperty("micronaut.test-resources");
             System.clearProperty("micronaut.test-resources-server-uri");
         }

--- a/src/main/docs/guide/configurationValidator.adoc
+++ b/src/main/docs/guide/configurationValidator.adoc
@@ -35,7 +35,7 @@ If a schema property is marked as deprecated (`"deprecated": true`), the validat
 
 By default unknown properties are treated as errors (and some schemas also enforce this via `additionalProperties: false`).
 
-Built-in suppression patterns silence known framework-managed properties such as `micronaut.home` and `micronaut.test-resources*`.
+Built-in suppression patterns silence known framework-managed properties such as `micronaut.home`, `micronaut.processing`, and `micronaut.test-resources*`.
 
 You can downgrade matching errors to warnings by configuring your own suppression patterns (for example `micronaut.http.*`).
 


### PR DESCRIPTION
## Summary
- add  to the built-in configuration-validator suppressions
- extend validator and CLI regression tests to keep the property silent by default
- document  as a built-in suppressed property

Related to micronaut-projects/micronaut-maven-plugin#1649.


