### PR TITLE
Allow case-insensitive config enum validation

### DIFF
--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/SchemaValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/SchemaValidator.java
@@ -418,7 +418,7 @@ final class SchemaValidator {
                 return true;
             }
             if (enumValue != null && value != null) {
-                if (enumValue.toString().equals(value.toString())) {
+                if (enumValue.toString().equalsIgnoreCase(value.toString())) {
                     return true;
                 }
             }

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/GeneratedConfigurationSchemasTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/GeneratedConfigurationSchemasTest.java
@@ -65,6 +65,20 @@ class GeneratedConfigurationSchemasTest {
         assertTrue(errors.stream().anyMatch(e -> e.property().equals("test.validation.extra") && e.message().contains("not present")));
     }
 
+    @Test
+    void validatesEnumConfigurationCaseInsensitively() {
+        Environment env = createEnvironment(Map.of(
+            "test.validation.mode", "a"
+        ));
+
+        ConfigurationJsonSchemaValidator validator = new ConfigurationJsonSchemaValidator();
+        validator.setFailOnNotPresent(true);
+
+        Set<ConfigurationError> errors = validator.validate(getClass().getClassLoader(), env);
+
+        assertFalse(errors.stream().anyMatch(e -> e.property().equals("test.validation.mode")), () -> "Unexpected enum errors: " + errors);
+    }
+
     private static Environment createEnvironment(Map<String, Object> properties) {
         ClassLoader classLoader = GeneratedConfigurationSchemasTest.class.getClassLoader();
         ApplicationContextConfiguration configuration = new ApplicationContextConfiguration() {


### PR DESCRIPTION
## Summary
- allow configuration enum validation to match string values case-insensitively
- add a regression for lowercase enum configuration values matching generated enum schemas

## Verification
- ./gradlew --console=plain :micronaut-json-schema-configuration-validator:test --tests io.micronaut.jsonschema.configuration.validator.GeneratedConfigurationSchemasTest