### PR TITLE
Handle nested config schemas and documented defaults

### DIFF
--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidator.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -151,7 +152,7 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
             }
         }
 
-        Map<String, Set<String>> nestedSchemaKeysByPrefix = nestedSchemaKeysByPrefix(schemasByPrefix.keySet());
+        Map<String, Set<List<String>>> nestedSchemaPathsByPrefix = nestedSchemaPathsByPrefix(schemasByPrefix.keySet());
 
         for (Map.Entry<String, List<ConfigurationSchema>> entry : schemasByPrefix.entrySet()) {
             String prefix = entry.getKey();
@@ -173,7 +174,7 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
                     failOnNotPresent,
                     rules,
                     errors,
-                    nestedSchemaKeysByPrefix,
+                    nestedSchemaPathsByPrefix,
                     overlappingPrefixKeys,
                     overlappingEachPropertySchemaKeys
                 );
@@ -244,42 +245,29 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
         }
     }
 
-    private static Map<String, Set<String>> nestedSchemaKeysByPrefix(Set<String> schemaPrefixes) {
+    private static Map<String, Set<List<String>>> nestedSchemaPathsByPrefix(Set<String> schemaPrefixes) {
         if (schemaPrefixes.isEmpty()) {
             return Map.of();
         }
-        Map<String, Set<String>> keysByPrefix = new LinkedHashMap<>(schemaPrefixes.size());
+        Map<String, Set<List<String>>> pathsByPrefix = new LinkedHashMap<>(schemaPrefixes.size());
         Set<String> prefixes = new LinkedHashSet<>(schemaPrefixes);
 
-        for (String fullPrefix : prefixes) {
-            addNestedSchemaKeys(prefixes, keysByPrefix, fullPrefix);
-        }
-
-        return keysByPrefix;
-    }
-
-    private static void addNestedSchemaKeys(Set<String> prefixes, Map<String, Set<String>> keysByPrefix, String fullPrefix) {
-        int dot = fullPrefix.indexOf('.');
-        if (dot == -1) {
-            return;
-        }
-        String parentPrefix = fullPrefix.substring(0, dot);
-        int start = dot + 1;
-
-        while (start < fullPrefix.length()) {
-            int nextDot = fullPrefix.indexOf('.', start);
-            String segment = nextDot == -1 ? fullPrefix.substring(start) : fullPrefix.substring(start, nextDot);
-
-            if (prefixes.contains(parentPrefix) && !StringUtils.isEmpty(segment)) {
-                keysByPrefix.computeIfAbsent(parentPrefix, p -> new LinkedHashSet<>()).add(segment);
+        for (String prefix : prefixes) {
+            String prefixWithDot = prefix + ".";
+            for (String fullPrefix : prefixes) {
+                if (fullPrefix.equals(prefix) || !fullPrefix.startsWith(prefixWithDot)) {
+                    continue;
+                }
+                String nestedPath = fullPrefix.substring(prefixWithDot.length());
+                if (StringUtils.isEmpty(nestedPath)) {
+                    continue;
+                }
+                pathsByPrefix.computeIfAbsent(prefix, p -> new LinkedHashSet<>())
+                    .add(Arrays.asList(nestedPath.split("\\.")));
             }
-
-            if (nextDot == -1) {
-                break;
-            }
-            parentPrefix = parentPrefix + "." + segment;
-            start = nextDot + 1;
         }
+
+        return pathsByPrefix;
     }
 
     private static Set<String> overlappingPrefixKeys(List<ConfigurationSchema> schemas) {
@@ -337,7 +325,7 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
             boolean failOnNotPresent,
             List<ConfigurationRule> rules,
             Set<ConfigurationError> errors,
-            Map<String, Set<String>> nestedSchemaKeysByPrefix,
+            Map<String, Set<List<String>>> nestedSchemaPathsByPrefix,
             Set<String> overlappingPrefixKeys,
             Set<String> overlappingEachPropertySchemaKeys
         ) {
@@ -345,9 +333,9 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
             String container = schema.micronaut() != null ? schema.micronaut().container() : null;
 
             if ("each-property".equals(kind) && "map".equals(container)) {
-                validateEachProperty(prefix, schema, classLoader, environment, jsonMapper, failOnNotPresent, rules, errors, nestedSchemaKeysByPrefix, overlappingEachPropertySchemaKeys);
+                validateEachProperty(prefix, schema, classLoader, environment, jsonMapper, failOnNotPresent, rules, errors, nestedSchemaPathsByPrefix, overlappingEachPropertySchemaKeys);
             } else {
-                validateConfigurationProperties(prefix, schema, classLoader, environment, jsonMapper, failOnNotPresent, rules, errors, nestedSchemaKeysByPrefix, overlappingPrefixKeys);
+                validateConfigurationProperties(prefix, schema, classLoader, environment, jsonMapper, failOnNotPresent, rules, errors, nestedSchemaPathsByPrefix, overlappingPrefixKeys);
             }
         }
 
@@ -360,7 +348,7 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
             boolean failOnNotPresent,
             List<ConfigurationRule> rules,
             Set<ConfigurationError> errors,
-            Map<String, Set<String>> nestedSchemaKeysByPrefix,
+            Map<String, Set<List<String>>> nestedSchemaPathsByPrefix,
             Set<String> overlappingPrefixKeys
         ) {
             if (!environment.containsProperties(prefix)) {
@@ -381,10 +369,10 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
             }
             Map<String, Object> instance = NestedPropertyMapBuilder.nest(flat);
             ConfigurationSchemaProperty root = ConfigurationSchemaPropertyAdapter.fromRoot(schema);
-
-            Map<String, Object> effectiveInstance = removeNestedSchemaKeys(prefix, instance, root, nestedSchemaKeysByPrefix);
-            effectiveInstance = removeOverlappingSchemaKeys(effectiveInstance, root, overlappingPrefixKeys);
             SchemaContext ctx = new SchemaContext(schema, classLoader, environment, jsonMapper, failOnNotPresent);
+
+            Map<String, Object> effectiveInstance = removeNestedSchemaKeys(prefix, instance, root, nestedSchemaPathsByPrefix, ctx);
+            effectiveInstance = removeOverlappingSchemaKeys(effectiveInstance, root, overlappingPrefixKeys);
             SchemaValidator.validateObject(ctx, root, effectiveInstance, prefix, null, errors);
 
             applyRules(rules, new ConfigurationValidationContext(environment, prefix, schema, root, instance), errors);
@@ -400,7 +388,7 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
             boolean failOnNotPresent,
             List<ConfigurationRule> rules,
             Set<ConfigurationError> errors,
-            Map<String, Set<String>> nestedSchemaKeysByPrefix,
+            Map<String, Set<List<String>>> nestedSchemaPathsByPrefix,
             Set<String> overlappingEachPropertySchemaKeys
         ) {
             SchemaContext ctx = new SchemaContext(schema, classLoader, environment, jsonMapper, failOnNotPresent);
@@ -432,6 +420,7 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
                     continue;
                 }
                 Map<String, Object> instance = NestedPropertyMapBuilder.nest(flat);
+                instance = unwrapRepeatedEachPropertyEntry(instance, entry, entrySchema);
                 Map<String, Object> effectiveInstance = removeOverlappingEachPropertySchemaKeys(instance, entrySchema, overlappingEachPropertySchemaKeys);
 
                 SchemaValidator.validateObject(ctx, entrySchema, effectiveInstance, entryPrefix, entry, errors);
@@ -439,6 +428,25 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
                 applyRules(rules, new ConfigurationValidationContext(environment, entryPrefix, schema, entrySchema, instance), errors);
                 applyRulesForNestedObjects(rules, environment, entryPrefix, schema, entrySchema, instance, errors);
             }
+        }
+
+        @SuppressWarnings("unchecked")
+        private static Map<String, Object> unwrapRepeatedEachPropertyEntry(
+            Map<String, Object> instance,
+            String entry,
+            ConfigurationSchemaProperty entrySchema
+        ) {
+            if (instance.size() != 1 || !instance.containsKey(entry)) {
+                return instance;
+            }
+            if (!(instance.get(entry) instanceof Map<?, ?> nested)) {
+                return instance;
+            }
+            Map<String, ConfigurationSchemaProperty> properties = entrySchema.properties();
+            if (properties != null && properties.containsKey(entry)) {
+                return instance;
+            }
+            return (Map<String, Object>) nested;
         }
 
         private static Map<String, Object> removeOverlappingEachPropertySchemaKeys(
@@ -524,31 +532,59 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
             String prefix,
             Map<String, Object> instance,
             ConfigurationSchemaProperty root,
-            Map<String, Set<String>> nestedSchemaKeysByPrefix
+            Map<String, Set<List<String>>> nestedSchemaPathsByPrefix,
+            SchemaContext ctx
         ) {
-            if (instance.isEmpty() || nestedSchemaKeysByPrefix.isEmpty()) {
+            if (instance.isEmpty() || nestedSchemaPathsByPrefix.isEmpty()) {
                 return instance;
             }
-            Set<String> nestedKeys = nestedSchemaKeysByPrefix.get(prefix);
-            if (nestedKeys == null || nestedKeys.isEmpty()) {
+            Set<List<String>> nestedPaths = nestedSchemaPathsByPrefix.get(prefix);
+            if (nestedPaths == null || nestedPaths.isEmpty()) {
                 return instance;
             }
 
-            Map<String, ConfigurationSchemaProperty> properties = root.properties();
             Map<String, Object> filtered = null;
-            for (String key : nestedKeys) {
-                if (!instance.containsKey(key)) {
-                    continue;
-                }
-                if (properties != null && properties.containsKey(key)) {
+            for (List<String> nestedPath : nestedPaths) {
+                if (nestedPath.isEmpty()) {
                     continue;
                 }
                 if (filtered == null) {
                     filtered = new LinkedHashMap<>(instance);
                 }
-                filtered.remove(key);
+                removeNestedSchemaPath(filtered, root, nestedPath, 0, ctx);
             }
             return filtered != null ? filtered : instance;
+        }
+
+        @SuppressWarnings("unchecked")
+        private static void removeNestedSchemaPath(
+            Map<String, Object> instance,
+            ConfigurationSchemaProperty schema,
+            List<String> path,
+            int index,
+            SchemaContext ctx
+        ) {
+            String segment = path.get(index);
+            if (!instance.containsKey(segment)) {
+                return;
+            }
+
+            ConfigurationSchemaProperty resolvedSchema = ctx.refResolver().resolveRef(schema);
+            Map<String, ConfigurationSchemaProperty> properties = resolvedSchema != null ? resolvedSchema.properties() : null;
+            ConfigurationSchemaProperty childSchema = properties != null ? properties.get(segment) : null;
+            if (childSchema == null) {
+                instance.remove(segment);
+                return;
+            }
+
+            if (index == path.size() - 1) {
+                return;
+            }
+
+            Object childValue = instance.get(segment);
+            if (childValue instanceof Map<?, ?> childMap) {
+                removeNestedSchemaPath((Map<String, Object>) childMap, childSchema, path, index + 1, ctx);
+            }
         }
 
         private static Map<String, Object> removeOverlappingSchemaKeys(

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidator.java
@@ -37,7 +37,9 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableSet;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
@@ -250,13 +252,13 @@ public final class ConfigurationJsonSchemaValidator implements ConfigurationVali
             return Map.of();
         }
         Map<String, Set<List<String>>> pathsByPrefix = new LinkedHashMap<>(schemaPrefixes.size());
-        Set<String> prefixes = new LinkedHashSet<>(schemaPrefixes);
+        NavigableSet<String> prefixes = new TreeSet<>(schemaPrefixes);
 
         for (String prefix : prefixes) {
             String prefixWithDot = prefix + ".";
-            for (String fullPrefix : prefixes) {
-                if (fullPrefix.equals(prefix) || !fullPrefix.startsWith(prefixWithDot)) {
-                    continue;
+            for (String fullPrefix : prefixes.tailSet(prefixWithDot, true)) {
+                if (!fullPrefix.startsWith(prefixWithDot)) {
+                    break;
                 }
                 String nestedPath = fullPrefix.substring(prefixWithDot.length());
                 if (StringUtils.isEmpty(nestedPath)) {

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/SchemaValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/SchemaValidator.java
@@ -418,7 +418,7 @@ final class SchemaValidator {
                 return true;
             }
             if (enumValue != null && value != null) {
-                if (enumValue.toString().equals(value.toString())) {
+                if (enumValue.toString().equalsIgnoreCase(value.toString())) {
                     return true;
                 }
             }

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/SchemaValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/SchemaValidator.java
@@ -39,6 +39,11 @@ import java.util.regex.Pattern;
 
 @Internal
 final class SchemaValidator {
+    private static final Pattern DEFAULTS_TO_PATTERN = Pattern.compile("\\bDefaults? to\\s+[`'\"]?([^`'\".,;)\\s]+)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern DEFAULT_VALUE_PAREN_PATTERN = Pattern.compile("\\bDefault value\\s*\\((?!\\s*\\{@value)([^)]+)\\)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern DEFAULT_VALUE_PATTERN = Pattern.compile("\\bDefault value\\s+[`'\"]?([^`'\".,;)\\s]+)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern DEFAULT_COLON_PATTERN = Pattern.compile("\\bDefault:\\s*[`'\"]?([^`'\".,;)\\s]+)", Pattern.CASE_INSENSITIVE);
+
     private SchemaValidator() {
     }
 
@@ -100,6 +105,9 @@ final class SchemaValidator {
                     if ((resolvedRequiredProperty != null && resolvedRequiredProperty.defaultValue() != null) || requiredProperty.defaultValue() != null) {
                         continue;
                     }
+                    if (hasValidDocumentedDefault(requiredProperty) || hasValidDocumentedDefault(resolvedRequiredProperty)) {
+                        continue;
+                    }
                 }
                 if (!instance.containsKey(req)) {
                     String missingComputed = computedPropertyName + "." + req;
@@ -129,7 +137,8 @@ final class SchemaValidator {
         boolean additionalPropertiesTrue = additionalProperties instanceof Boolean b && b;
         boolean additionalPropertiesFalse = additionalProperties instanceof Boolean b && !b;
         ConfigurationSchemaProperty additionalSchema = ctx.refResolver().resolveAdditionalPropertiesSchema(schema);
-        if (ctx.failOnNotPresent() || additionalPropertiesFalse || additionalSchema != null) {
+        ConfigurationSchemaProperty wildcardSchema = properties.get("*");
+        if (ctx.failOnNotPresent() || additionalPropertiesFalse || additionalSchema != null || wildcardSchema != null) {
             for (Map.Entry<String, Object> entry : instance.entrySet()) {
                 String key = entry.getKey();
                 if (properties.containsKey(key)) {
@@ -138,6 +147,14 @@ final class SchemaValidator {
 
                 String unknownComputed = computedPropertyName + "." + key;
                 String unknownResolved = ctx.resolvedPropertyName(unknownComputed, null, wildcardReplacement);
+
+                if (wildcardSchema != null) {
+                    String wildcardComputed = computedPropertyName + ".*";
+                    String wildcardResolved = ctx.resolvedPropertyName(wildcardComputed, wildcardSchema.micronautPath(), key);
+                    Object coerced = ValueCoercer.coerce(ctx, wildcardSchema, wildcardResolved, key, entry.getValue(), errors);
+                    validateNode(ctx, wildcardSchema, coerced, wildcardComputed, wildcardResolved, key, errors);
+                    continue;
+                }
 
                 if (additionalSchema != null) {
                     Object coerced = ValueCoercer.coerce(ctx, additionalSchema, unknownResolved, wildcardReplacement, entry.getValue(), errors);
@@ -473,6 +490,71 @@ final class SchemaValidator {
             }
         }
         return null;
+    }
+
+    private static boolean hasValidDocumentedDefault(@Nullable ConfigurationSchemaProperty property) {
+        if (property == null) {
+            return false;
+        }
+        String documentedDefault = documentedDefault(property.description());
+        if (documentedDefault == null) {
+            return false;
+        }
+
+        Object constValue = property.constValue();
+        if (constValue != null && !Objects.equals(constValue.toString(), documentedDefault)) {
+            return false;
+        }
+
+        Collection<Object> enumValues = property.enumValues();
+        if (enumValues != null && !enumContains(enumValues, documentedDefault)) {
+            return false;
+        }
+
+        ConfigurationSchemaType type = SchemaTypes.toType(property.type());
+        if (type == null) {
+            return true;
+        }
+        return switch (type) {
+            case STRING -> true;
+            case BOOLEAN -> "true".equalsIgnoreCase(documentedDefault) || "false".equalsIgnoreCase(documentedDefault);
+            case INTEGER -> toBigDecimal(documentedDefault) != null && toBigDecimal(documentedDefault).stripTrailingZeros().scale() <= 0;
+            case NUMBER -> toBigDecimal(documentedDefault) != null;
+            default -> false;
+        };
+    }
+
+    @Nullable
+    private static String documentedDefault(@Nullable String description) {
+        if (description == null) {
+            return null;
+        }
+        for (Pattern pattern : List.of(DEFAULTS_TO_PATTERN, DEFAULT_VALUE_PAREN_PATTERN, DEFAULT_VALUE_PATTERN, DEFAULT_COLON_PATTERN)) {
+            java.util.regex.Matcher matcher = pattern.matcher(description);
+            if (matcher.find()) {
+                String candidate = cleanDocumentedDefault(matcher.group(1));
+                if (candidate != null) {
+                    return candidate;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    private static String cleanDocumentedDefault(String candidate) {
+        String value = candidate.strip();
+        while (!value.isEmpty() && "`'\".,;)".indexOf(value.charAt(value.length() - 1)) >= 0) {
+            value = value.substring(0, value.length() - 1).strip();
+        }
+        if (value.isEmpty() || value.indexOf('{') >= 0 || value.indexOf('#') >= 0) {
+            return null;
+        }
+        String lower = value.toLowerCase(Locale.ROOT);
+        if ("null".equals(lower) || "none".equals(lower) || "n/a".equals(lower)) {
+            return null;
+        }
+        return value;
     }
 
     private static final class PropertySuggester {

--- a/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/SchemaValidator.java
+++ b/json-schema-configuration-validator/src/main/java/io/micronaut/jsonschema/configuration/validator/SchemaValidator.java
@@ -39,10 +39,16 @@ import java.util.regex.Pattern;
 
 @Internal
 final class SchemaValidator {
-    private static final Pattern DEFAULTS_TO_PATTERN = Pattern.compile("\\bDefaults? to\\s+[`'\"]?([^`'\".,;)\\s]+)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern DEFAULTS_TO_PATTERN = Pattern.compile("\\bDefaults? to\\s+[`'\"]?([^\\s]+)", Pattern.CASE_INSENSITIVE);
     private static final Pattern DEFAULT_VALUE_PAREN_PATTERN = Pattern.compile("\\bDefault value\\s*\\((?!\\s*\\{@value)([^)]+)\\)", Pattern.CASE_INSENSITIVE);
-    private static final Pattern DEFAULT_VALUE_PATTERN = Pattern.compile("\\bDefault value\\s+[`'\"]?([^`'\".,;)\\s]+)", Pattern.CASE_INSENSITIVE);
-    private static final Pattern DEFAULT_COLON_PATTERN = Pattern.compile("\\bDefault:\\s*[`'\"]?([^`'\".,;)\\s]+)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern DEFAULT_VALUE_PATTERN = Pattern.compile("\\bDefault value\\s+[`'\"]?([^\\s]+)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern DEFAULT_COLON_PATTERN = Pattern.compile("\\bDefault:\\s*[`'\"]?([^\\s]+)", Pattern.CASE_INSENSITIVE);
+    private static final List<Pattern> DOCUMENTED_DEFAULT_PATTERNS = List.of(
+        DEFAULTS_TO_PATTERN,
+        DEFAULT_VALUE_PAREN_PATTERN,
+        DEFAULT_VALUE_PATTERN,
+        DEFAULT_COLON_PATTERN
+    );
 
     private SchemaValidator() {
     }
@@ -518,7 +524,10 @@ final class SchemaValidator {
         return switch (type) {
             case STRING -> true;
             case BOOLEAN -> "true".equalsIgnoreCase(documentedDefault) || "false".equalsIgnoreCase(documentedDefault);
-            case INTEGER -> toBigDecimal(documentedDefault) != null && toBigDecimal(documentedDefault).stripTrailingZeros().scale() <= 0;
+            case INTEGER -> {
+                BigDecimal value = toBigDecimal(documentedDefault);
+                yield value != null && value.stripTrailingZeros().scale() <= 0;
+            }
             case NUMBER -> toBigDecimal(documentedDefault) != null;
             default -> false;
         };
@@ -529,7 +538,7 @@ final class SchemaValidator {
         if (description == null) {
             return null;
         }
-        for (Pattern pattern : List.of(DEFAULTS_TO_PATTERN, DEFAULT_VALUE_PAREN_PATTERN, DEFAULT_VALUE_PATTERN, DEFAULT_COLON_PATTERN)) {
+        for (Pattern pattern : DOCUMENTED_DEFAULT_PATTERNS) {
             java.util.regex.Matcher matcher = pattern.matcher(description);
             if (matcher.find()) {
                 String candidate = cleanDocumentedDefault(matcher.group(1));

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidatorTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidatorTest.java
@@ -119,6 +119,10 @@ class ConfigurationJsonSchemaValidatorTest {
             && e.message().contains("Missing required")), () -> "Unexpected missing required error for initial-pool-size: " + errors);
         assertFalse(errors.stream().anyMatch(e -> e.property().equals("test.bindable.max-pool-size")
             && e.message().contains("Missing required")), () -> "Unexpected missing required error for max-pool-size: " + errors);
+        assertFalse(errors.stream().anyMatch(e -> e.property().equals("test.bindable.documented-mode")
+            && e.message().contains("Missing required")), () -> "Unexpected missing required error for valid documented default: " + errors);
+        assertTrue(errors.stream().anyMatch(e -> e.property().equals("test.bindable.invalid-documented-mode")
+            && e.message().contains("Missing required")), () -> "Expected missing required error for invalid documented default: " + errors);
     }
 
     @Test
@@ -238,6 +242,43 @@ class ConfigurationJsonSchemaValidatorTest {
         assertTrue(errors.stream().anyMatch(e -> e.property().equals("test.executors.alpha.n-threads") && e.message().contains(">=")));
         assertTrue(errors.stream().anyMatch(e -> e.property().equals("test.executors.beta.n-threads") && e.message().contains("Missing required")));
         assertTrue(errors.stream().anyMatch(e -> e.property().equals("test.executors.beta.unknown") && e.message().contains("not present")));
+    }
+
+    @Test
+    void nestedConfigurationSchemaBranchesAreNotReportedByParentSchemas() {
+        Environment environment = createEnvironment(Map.of(
+            "test.security.token.enabled", StringUtils.TRUE,
+            "test.security.token.jwt.generator.refresh-token.secret", "pleaseChangeThisSecretForANewOne",
+            "test.security.token.jwt.signatures.enabled", StringUtils.TRUE,
+            "test.security.token.jwt.signatures.secret.generator.secret", "pleaseChangeThisSecretForANewOne"
+        ));
+
+        ConfigurationJsonSchemaValidator validator = new ConfigurationJsonSchemaValidator();
+        validator.setFailOnNotPresent(true);
+
+        Set<ConfigurationError> errors = validator.validate(getClass().getClassLoader(), environment);
+
+        assertFalse(errors.stream().anyMatch(e -> e.property().equals("test.security.token.jwt")),
+            () -> "Nested JWT schema branch should be validated by its own schema, got: " + errors);
+        assertFalse(errors.stream().anyMatch(e -> e.property().equals("test.security.token.jwt.signatures.secret")),
+            () -> "Nested each-property schema branch should be validated by its own schema, got: " + errors);
+        assertFalse(errors.stream().anyMatch(e -> e.property().equals("test.security.token.jwt.signatures.secret.generator")),
+            () -> "Each-property entry should be validated by its own schema, got: " + errors);
+    }
+
+    @Test
+    void repeatedEachPropertyEntrySegmentIsUnwrappedBeforeValidation() {
+        Environment environment = createEnvironment(Map.of(
+            "test.security.token.jwt.signatures.secret.generator.generator.secret", "pleaseChangeThisSecretForANewOne"
+        ));
+
+        ConfigurationJsonSchemaValidator validator = new ConfigurationJsonSchemaValidator();
+        validator.setFailOnNotPresent(true);
+
+        Set<ConfigurationError> errors = validator.validate(getClass().getClassLoader(), environment);
+
+        assertFalse(errors.stream().anyMatch(e -> e.property().equals("test.security.token.jwt.signatures.secret.generator")),
+            () -> "Repeated each-property entry segment should be unwrapped, got: " + errors);
     }
 
     @Test

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidatorTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/ConfigurationJsonSchemaValidatorTest.java
@@ -121,6 +121,10 @@ class ConfigurationJsonSchemaValidatorTest {
             && e.message().contains("Missing required")), () -> "Unexpected missing required error for max-pool-size: " + errors);
         assertFalse(errors.stream().anyMatch(e -> e.property().equals("test.bindable.documented-mode")
             && e.message().contains("Missing required")), () -> "Unexpected missing required error for valid documented default: " + errors);
+        assertFalse(errors.stream().anyMatch(e -> e.property().equals("test.bindable.documented-host")
+            && e.message().contains("Missing required")), () -> "Unexpected missing required error for dotted documented default: " + errors);
+        assertFalse(errors.stream().anyMatch(e -> e.property().equals("test.bindable.documented-ratio")
+            && e.message().contains("Missing required")), () -> "Unexpected missing required error for decimal documented default: " + errors);
         assertTrue(errors.stream().anyMatch(e -> e.property().equals("test.bindable.invalid-documented-mode")
             && e.message().contains("Missing required")), () -> "Expected missing required error for invalid documented default: " + errors);
     }

--- a/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/GeneratedConfigurationSchemasTest.java
+++ b/json-schema-configuration-validator/src/test/java/io/micronaut/jsonschema/configuration/validator/GeneratedConfigurationSchemasTest.java
@@ -65,6 +65,20 @@ class GeneratedConfigurationSchemasTest {
         assertTrue(errors.stream().anyMatch(e -> e.property().equals("test.validation.extra") && e.message().contains("not present")));
     }
 
+    @Test
+    void validatesEnumConfigurationCaseInsensitively() {
+        Environment env = createEnvironment(Map.of(
+            "test.validation.mode", "a"
+        ));
+
+        ConfigurationJsonSchemaValidator validator = new ConfigurationJsonSchemaValidator();
+        validator.setFailOnNotPresent(true);
+
+        Set<ConfigurationError> errors = validator.validate(getClass().getClassLoader(), env);
+
+        assertFalse(errors.stream().anyMatch(e -> e.property().equals("test.validation.mode")), () -> "Unexpected enum errors: " + errors);
+    }
+
     private static Environment createEnvironment(Map<String, Object> properties) {
         ClassLoader classLoader = GeneratedConfigurationSchemasTest.class.getClassLoader();
         ApplicationContextConfiguration configuration = new ApplicationContextConfiguration() {

--- a/json-schema-configuration-validator/src/test/resources/META-INF/micronaut-configuration-schemas/test.bindable.BindableDefaultsConfig.json
+++ b/json-schema-configuration-validator/src/test/resources/META-INF/micronaut-configuration-schemas/test.bindable.BindableDefaultsConfig.json
@@ -33,6 +33,18 @@
       "x-micronaut-javaType": "java.lang.String",
       "x-micronaut-path": "test.bindable.documented-mode"
     },
+    "documented-host": {
+      "type": "string",
+      "description": "Default: 127.0.0.1",
+      "x-micronaut-javaType": "java.lang.String",
+      "x-micronaut-path": "test.bindable.documented-host"
+    },
+    "documented-ratio": {
+      "type": "number",
+      "description": "Default value 1.0",
+      "x-micronaut-javaType": "java.math.BigDecimal",
+      "x-micronaut-path": "test.bindable.documented-ratio"
+    },
     "invalid-documented-mode": {
       "type": "string",
       "enum": ["RS256"],
@@ -45,6 +57,8 @@
     "initial-pool-size",
     "max-pool-size",
     "documented-mode",
+    "documented-host",
+    "documented-ratio",
     "invalid-documented-mode"
   ]
 }

--- a/json-schema-configuration-validator/src/test/resources/META-INF/micronaut-configuration-schemas/test.bindable.BindableDefaultsConfig.json
+++ b/json-schema-configuration-validator/src/test/resources/META-INF/micronaut-configuration-schemas/test.bindable.BindableDefaultsConfig.json
@@ -25,10 +25,26 @@
       "type": "boolean",
       "x-micronaut-javaType": "java.lang.Boolean",
       "x-micronaut-path": "test.bindable.enabled"
+    },
+    "documented-mode": {
+      "type": "string",
+      "enum": ["HS256"],
+      "description": "Defaults to HS256",
+      "x-micronaut-javaType": "java.lang.String",
+      "x-micronaut-path": "test.bindable.documented-mode"
+    },
+    "invalid-documented-mode": {
+      "type": "string",
+      "enum": ["RS256"],
+      "description": "Defaults to HS256",
+      "x-micronaut-javaType": "java.lang.String",
+      "x-micronaut-path": "test.bindable.invalid-documented-mode"
     }
   },
   "required": [
     "initial-pool-size",
-    "max-pool-size"
+    "max-pool-size",
+    "documented-mode",
+    "invalid-documented-mode"
   ]
 }

--- a/json-schema-configuration-validator/src/test/resources/META-INF/micronaut-configuration-schemas/test.security.JwtConfiguration.json
+++ b/json-schema-configuration-validator/src/test/resources/META-INF/micronaut-configuration-schemas/test.security.JwtConfiguration.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:micronaut:config:test.security.JwtConfiguration",
+  "title": "test.security.JwtConfiguration",
+  "x-micronaut": {
+    "prefix": "test.security.token.jwt",
+    "type": "test.security.JwtConfiguration",
+    "kind": "configuration-properties"
+  },
+  "type": "object",
+  "properties": {
+    "generator": {
+      "type": "object",
+      "properties": {
+        "refresh-token": {
+          "type": "object",
+          "properties": {
+            "secret": {
+              "type": "string",
+              "x-micronaut-path": "test.security.token.jwt.generator.refresh-token.secret"
+            }
+          },
+          "required": ["secret"]
+        }
+      }
+    },
+    "signatures": {
+      "type": "object",
+      "properties": {
+        "secret": {
+          "type": "object",
+          "properties": {
+            "*": {
+              "type": "object",
+              "properties": {
+                "secret": {
+                  "type": "string",
+                  "x-micronaut-path": "test.security.token.jwt.signatures.secret.*.secret"
+                }
+              },
+              "required": ["secret"]
+            }
+          }
+        },
+        "enabled": {
+          "type": "boolean",
+          "x-micronaut-path": "test.security.token.jwt.signatures.enabled"
+        }
+      }
+    }
+  }
+}

--- a/json-schema-configuration-validator/src/test/resources/META-INF/micronaut-configuration-schemas/test.security.SecretSignatureConfiguration.json
+++ b/json-schema-configuration-validator/src/test/resources/META-INF/micronaut-configuration-schemas/test.security.SecretSignatureConfiguration.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:micronaut:config:test.security.SecretSignatureConfiguration",
+  "title": "test.security.SecretSignatureConfiguration",
+  "x-micronaut": {
+    "prefix": "test.security.token.jwt.signatures.secret",
+    "type": "test.security.SecretSignatureConfiguration",
+    "kind": "each-property",
+    "container": "map"
+  },
+  "type": "object",
+  "minProperties": 1,
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "secret": {
+        "type": "string",
+        "x-micronaut-path": "test.security.token.jwt.signatures.secret.*.secret"
+      }
+    },
+    "required": ["secret"]
+  }
+}

--- a/json-schema-configuration-validator/src/test/resources/META-INF/micronaut-configuration-schemas/test.security.SecurityConfiguration.json
+++ b/json-schema-configuration-validator/src/test/resources/META-INF/micronaut-configuration-schemas/test.security.SecurityConfiguration.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:micronaut:config:test.security.SecurityConfiguration",
+  "title": "test.security.SecurityConfiguration",
+  "x-micronaut": {
+    "prefix": "test.security",
+    "type": "test.security.SecurityConfiguration",
+    "kind": "configuration-properties"
+  },
+  "type": "object",
+  "properties": {
+    "token": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "x-micronaut-path": "test.security.token.enabled"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- validate nested configuration schema branches without parent-schema false positives
- support wildcard map-entry schemas used by generated configuration schema fragments
- allow documented required defaults only when the extracted value satisfies const, enum, and JSON type constraints

## Verification
- ./gradlew --console=plain :micronaut-json-schema-configuration-validator:test --tests io.micronaut.jsonschema.configuration.validator.ConfigurationJsonSchemaValidatorTest
- ./gradlew --console=plain :micronaut-json-schema-configuration-validator:test --tests io.micronaut.jsonschema.configuration.validator.GeneratedConfigurationSchemasTest
- ./gradlew --console=plain --include-build ../json-schema micronautSecurityJwtRunPythonTestScript (from guides.pyronaut)