### PR TITLE
Honor @JsonProperty on enum constants in generated schemas

### DIFF
--- a/json-schema-processor/src/main/java/io/micronaut/jsonschema/visitor/JsonSchemaVisitor.java
+++ b/json-schema-processor/src/main/java/io/micronaut/jsonschema/visitor/JsonSchemaVisitor.java
@@ -15,11 +15,13 @@
  */
 package io.micronaut.jsonschema.visitor;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import tools.jackson.databind.ObjectMapper;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.NonNull;
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.EnumConstantElement;
 import io.micronaut.inject.ast.EnumElement;
 import io.micronaut.inject.ast.PropertyElement;
 import io.micronaut.inject.ast.TypedElement;
@@ -204,9 +206,8 @@ public final class JsonSchemaVisitor implements TypeElementVisitor<JsonSchema, O
                 schema.setUniqueItems(true);
             }
         } else if (!type.isPrimitive() && type.getRawClassElement() instanceof EnumElement enumElement) {
-            // Enum values must be camel case
             schema.addType(Type.STRING)
-                .setEnumValues(enumElement.values().stream().map(v -> (Object) v).toList());
+                .setEnumValues(enumValues(enumElement));
             context.currentOriginatingElements().add(enumElement);
         } else if (type.isAssignable(Number.class)) {
             switch (type.getName()) {
@@ -236,6 +237,22 @@ public final class JsonSchemaVisitor implements TypeElementVisitor<JsonSchema, O
                 default -> setBeanSchemaProperties(type, visitorContext, context, schema);
             }
         }
+    }
+
+    private static List<Object> enumValues(EnumElement enumElement) {
+        List<EnumConstantElement> enumConstants = enumElement.elements();
+        if (enumConstants.isEmpty()) {
+            return enumElement.values().stream().map(v -> (Object) v).toList();
+        }
+        return enumConstants.stream().map(JsonSchemaVisitor::enumValue).toList();
+    }
+
+    private static Object enumValue(EnumConstantElement enumConstant) {
+        AnnotationValue<JsonProperty> jsonProperty = enumConstant.getAnnotation(JsonProperty.class);
+        if (jsonProperty != null) {
+            return jsonProperty.stringValue().orElse("");
+        }
+        return enumConstant.getName();
     }
 
     public static void setBeanSchemaProperties(ClassElement element, VisitorContext visitorContext, JsonSchemaContext context, Schema schema) {

--- a/json-schema-processor/src/test/groovy/io/micronaut/jsonschema/visitor/JacksonJsonSchemaVisitorSpec.groovy
+++ b/json-schema-processor/src/test/groovy/io/micronaut/jsonschema/visitor/JacksonJsonSchemaVisitorSpec.groovy
@@ -2,7 +2,6 @@ package io.micronaut.jsonschema.visitor
 
 import io.micronaut.jsonschema.model.Schema
 
-
 class JacksonJsonSchemaVisitorSpec extends AbstractJsonSchemaSpec {
 
     void "schema with jackson property annotations"() {
@@ -30,6 +29,43 @@ class JacksonJsonSchemaVisitorSpec extends AbstractJsonSchemaSpec {
         schema.properties['name'].type == [Schema.Type.STRING]
         schema.properties['age'] == null
         schema.properties['weight (kg)'].type == [Schema.Type.NUMBER]
+    }
+
+    void "schema with JsonProperty annotations on enum constants"() {
+        given:
+        def schema = buildJsonSchema('test.Product', 'product', """
+        package test;
+
+        import com.fasterxml.jackson.annotation.*;
+        import io.micronaut.jsonschema.JsonSchema;
+
+        @JsonSchema
+        public record Product(
+                PriceType priceType,
+                MixedType mixedType
+        ) {
+        }
+
+        enum PriceType {
+            @JsonProperty("M")
+            meter,
+            @JsonProperty("K")
+            kilo
+        }
+
+        enum MixedType {
+            @JsonProperty("custom")
+            CUSTOM,
+            DEFAULT
+        }
+""")
+
+        expect:
+        schema.title == "Product"
+        schema.properties['priceType'].type == [Schema.Type.STRING]
+        schema.properties['priceType'].enumValues == ["M", "K"]
+        schema.properties['mixedType'].type == [Schema.Type.STRING]
+        schema.properties['mixedType'].enumValues == ["custom", "DEFAULT"]
     }
 
     void "schema with subtypes"() {


### PR DESCRIPTION
Closes : #366 
 Enum schema values now use EnumConstantElement metadata.                                                                                                                                              
       - If an enum constant has @JsonProperty, schema uses that value.                                                                                                                                        
       - Unannotated constants fall back to the enum constant name.                                                                                                                                            
       - Keeps fallback to previous enumElement.values() behavior when enum constant elements are unavailable.   