### PR TITLE
Map Oracle integral NUMBER metadata to Java long in record generation

### DIFF
--- a/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/aggregator/TypeAggregator.java
+++ b/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/aggregator/TypeAggregator.java
@@ -56,25 +56,25 @@ import static java.lang.String.join;
 @Internal
 public final class TypeAggregator {
 
-    private static final String JSON_TYPE_INTEGER = "integer";
-    private static final String JSON_TYPE_NUMBER = "number";
-
     public static final Map<String, TypeDef> TYPE_MAP;
 
-    public static final Map<String, TypeDef> TYPE_MAP_NULLABLE = CollectionUtils.mapOf(
-        JSON_TYPE_INTEGER, TypeDef.Primitive.INT_WRAPPER,
-        "boolean", TypeDef.Primitive.BOOLEAN_WRAPPER,
-        "array", TypeDef.of(List.class),
-        "void", TypeDef.VOID,
-        "string", TypeDef.STRING,
-        "object", TypeDef.OBJECT,
-        JSON_TYPE_NUMBER, TypeDef.Primitive.FLOAT_WRAPPER,
-        "null", TypeDef.OBJECT
-    );
+    public static final Map<String, TypeDef> TYPE_MAP_NULLABLE;
 
+    private static final String JSON_TYPE_INTEGER = "integer";
+    private static final String JSON_TYPE_NUMBER = "number";
     private static final String UNSUPPORTED_KEYWORD = "UNSUPPORTED_KEYWORD";
 
     static {
+        TYPE_MAP_NULLABLE = CollectionUtils.mapOf(
+            JSON_TYPE_INTEGER, TypeDef.Primitive.INT_WRAPPER,
+            "boolean", TypeDef.Primitive.BOOLEAN_WRAPPER,
+            "array", TypeDef.of(List.class),
+            "void", TypeDef.VOID,
+            "string", TypeDef.STRING,
+            "object", TypeDef.OBJECT,
+            JSON_TYPE_NUMBER, TypeDef.Primitive.FLOAT_WRAPPER,
+            "null", TypeDef.OBJECT
+        );
         TYPE_MAP = new HashMap<>();
         TYPE_MAP.putAll(TYPE_MAP_NULLABLE);
         TYPE_MAP.put(JSON_TYPE_INTEGER, TypeDef.Primitive.INT);

--- a/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/aggregator/TypeAggregator.java
+++ b/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/aggregator/TypeAggregator.java
@@ -56,16 +56,19 @@ import static java.lang.String.join;
 @Internal
 public final class TypeAggregator {
 
+    private static final String JSON_TYPE_INTEGER = "integer";
+    private static final String JSON_TYPE_NUMBER = "number";
+
     public static final Map<String, TypeDef> TYPE_MAP;
 
     public static final Map<String, TypeDef> TYPE_MAP_NULLABLE = CollectionUtils.mapOf(
-        "integer", TypeDef.Primitive.INT_WRAPPER,
+        JSON_TYPE_INTEGER, TypeDef.Primitive.INT_WRAPPER,
         "boolean", TypeDef.Primitive.BOOLEAN_WRAPPER,
         "array", TypeDef.of(List.class),
         "void", TypeDef.VOID,
         "string", TypeDef.STRING,
         "object", TypeDef.OBJECT,
-        "number", TypeDef.Primitive.FLOAT_WRAPPER,
+        JSON_TYPE_NUMBER, TypeDef.Primitive.FLOAT_WRAPPER,
         "null", TypeDef.OBJECT
     );
 
@@ -74,9 +77,9 @@ public final class TypeAggregator {
     static {
         TYPE_MAP = new HashMap<>();
         TYPE_MAP.putAll(TYPE_MAP_NULLABLE);
-        TYPE_MAP.put("integer", TypeDef.Primitive.INT);
+        TYPE_MAP.put(JSON_TYPE_INTEGER, TypeDef.Primitive.INT);
         TYPE_MAP.put("boolean", TypeDef.Primitive.BOOLEAN);
-        TYPE_MAP.put("number", TypeDef.Primitive.FLOAT);
+        TYPE_MAP.put(JSON_TYPE_NUMBER, TypeDef.Primitive.FLOAT);
     }
 
     private TypeAggregator() {

--- a/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/aggregator/TypeAggregator.java
+++ b/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/aggregator/TypeAggregator.java
@@ -264,11 +264,11 @@ public final class TypeAggregator {
 
     private static TypeDef getOracleExtendedTypeDef(Schema schema, Schema.Type type, boolean nullable) {
         if (!schema.hasExtendedType()) {
-            return null;
+            return getOracleIntegralNumberTypeDef(schema, type, nullable);
         }
         String extendedType = firstExtendedType(schema);
         if (extendedType == null || "null".equalsIgnoreCase(extendedType)) {
-            return null;
+            return getOracleIntegralNumberTypeDef(schema, type, nullable);
         }
         return switch (extendedType.toLowerCase(Locale.ENGLISH)) {
             case "date", "timestamp" ->
@@ -281,8 +281,21 @@ public final class TypeAggregator {
                 isNumberLike(type) ? nullable ? ClassTypeDef.of(Double.class) : TypeDef.Primitive.DOUBLE : null;
             case "float" ->
                 isNumberLike(type) ? nullable ? TypeDef.Primitive.FLOAT_WRAPPER : TypeDef.Primitive.FLOAT : null;
+            case "number", "integer" -> getOracleIntegralNumberTypeDef(schema, type, nullable);
             default -> null;
         };
+    }
+
+    private static TypeDef getOracleIntegralNumberTypeDef(Schema schema, Schema.Type type, boolean nullable) {
+        if (!Schema.Type.NUMBER.equals(type) || !Integer.valueOf(0).equals(schema.getSqlScale())) {
+            return null;
+        }
+        // Oracle NUMBER(19,0), commonly used for identifiers, is represented as long in the
+        // records profile. The default JSON Schema generator is intentionally unaffected.
+        if (schema.getSqlPrecision() != null && schema.getSqlPrecision() <= 9) {
+            return nullable ? TypeDef.Primitive.INT_WRAPPER : TypeDef.Primitive.INT;
+        }
+        return nullable ? TypeDef.Primitive.LONG_WRAPPER : TypeDef.Primitive.LONG;
     }
 
     private static String firstExtendedType(Schema schema) {

--- a/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/aggregator/TypeAggregator.java
+++ b/json-schema-generator/src/main/java/io/micronaut/jsonschema/generator/aggregator/TypeAggregator.java
@@ -284,7 +284,7 @@ public final class TypeAggregator {
                 isNumberLike(type) ? nullable ? ClassTypeDef.of(Double.class) : TypeDef.Primitive.DOUBLE : null;
             case "float" ->
                 isNumberLike(type) ? nullable ? TypeDef.Primitive.FLOAT_WRAPPER : TypeDef.Primitive.FLOAT : null;
-            case "number", "integer" -> getOracleIntegralNumberTypeDef(schema, type, nullable);
+            case JSON_TYPE_NUMBER, JSON_TYPE_INTEGER -> getOracleIntegralNumberTypeDef(schema, type, nullable);
             default -> null;
         };
     }

--- a/json-schema-generator/src/test/groovy/io/micronaut/jsonschema/generator/OracleRecordProfileSpec.groovy
+++ b/json-schema-generator/src/test/groovy/io/micronaut/jsonschema/generator/OracleRecordProfileSpec.groovy
@@ -4,6 +4,53 @@ import com.github.javaparser.ast.body.RecordDeclaration
 
 class OracleRecordProfileSpec extends AbstractGeneratorSpec {
 
+    void "oracle duality view NUMBER precision maps required identifiers to long"() {
+        when:
+        def content = generateRecordProfileTypeAndGetContent("DeptEmployees", '''
+        {
+          "title":"DeptEmployees",
+          "type":"object",
+          "properties":{
+            "_id":{
+              "type":"number",
+              "extendedType":"number",
+              "sqlPrecision":19,
+              "sqlScale":0
+            },
+            "employees":{
+              "type":"array",
+              "items":{
+                "type":"object",
+                "properties":{
+                  "employeeNumber":{
+                    "type":"number",
+                    "extendedType":"number",
+                    "sqlPrecision":19,
+                    "sqlScale":0
+                  },
+                  "salary":{
+                    "type":"number",
+                    "extendedType":"number",
+                    "sqlPrecision":7,
+                    "sqlScale":2
+                  }
+                },
+                "required":["employeeNumber"],
+                "additionalProperties":false
+              }
+            }
+          },
+          "required":["_id"],
+          "additionalProperties":false
+        }
+        ''')
+
+        then:
+        content.contains("@NotNull long _id")
+        content.contains("@NotNull long employeeNumber")
+        content.contains("Float salary")
+    }
+
     void "oracle profile generates JsonSchema records with default type mappings"() {
         when:
         def type = (RecordDeclaration) generateRecordProfileType("Product", '''
@@ -98,6 +145,8 @@ class OracleRecordProfileSpec extends AbstractGeneratorSpec {
                 {"type":"number","extendedType":"number","sqlPrecision":10,"sqlScale":0}
               ]
             },
+            "departmentId":{"type":"number","extendedType":"number","sqlPrecision":19,"sqlScale":0},
+            "amount":{"type":"number","extendedType":"number","sqlPrecision":7,"sqlScale":2},
             "createdAt":{
               "oneOf":[
                 {"type":"null","extendedType":"null"},
@@ -120,7 +169,9 @@ class OracleRecordProfileSpec extends AbstractGeneratorSpec {
 
         then:
         content.contains("@Nullable @Size(max = 20) String status")
-        content.contains("@Nullable Float floorNo")
+        content.contains("@Nullable Long floorNo")
+        content.contains("Long departmentId")
+        content.contains("Float amount")
         content.contains("@Nullable ZonedDateTime createdAt")
         content.contains("LocalDateTime updatedAt")
         content.contains("LocalDateTime businessDate")

--- a/json-schema-generator/src/test/groovy/io/micronaut/jsonschema/generator/OracleRecordProfileSpec.groovy
+++ b/json-schema-generator/src/test/groovy/io/micronaut/jsonschema/generator/OracleRecordProfileSpec.groovy
@@ -4,6 +4,34 @@ import com.github.javaparser.ast.body.RecordDeclaration
 
 class OracleRecordProfileSpec extends AbstractGeneratorSpec {
 
+    void "oracle numeric metadata covers integer precision and scale branches"() {
+        when:
+        def content = generateRecordProfileTypeAndGetContent("NumericMetadata", '''
+        {
+          "title":"NumericMetadata",
+          "type":"object",
+          "properties":{
+            "small":{"type":"number","extendedType":"number","sqlPrecision":9,"sqlScale":0},
+            "large":{"type":"number","extendedType":"number","sqlPrecision":19,"sqlScale":0},
+            "integerHint":{"type":"number","extendedType":"integer","sqlPrecision":19,"sqlScale":0},
+            "nullHint":{"type":"number","extendedType":"null","sqlPrecision":19,"sqlScale":0},
+            "decimal":{"type":"number","extendedType":"number","sqlPrecision":7,"sqlScale":2},
+            "withoutHint":{"type":"number","sqlPrecision":19,"sqlScale":0}
+          },
+          "required":["small","large","integerHint","nullHint","decimal","withoutHint"],
+          "additionalProperties":false
+        }
+        ''')
+
+        then:
+        content.contains("int small")
+        content.contains("long large")
+        content.contains("long integerHint")
+        content.contains("long nullHint")
+        content.contains("float decimal")
+        content.contains("long withoutHint")
+    }
+
     void "oracle duality view NUMBER precision maps required identifiers to long"() {
         when:
         def content = generateRecordProfileTypeAndGetContent("DeptEmployees", '''


### PR DESCRIPTION
Followup of #370

Oracle JSON Relational Duality Views expose integral columns such as `NUMBER(19,0)` as JSON Schema:

  ```
{
    "type": "number",
    "extendedType": "number",
    "sqlPrecision": 19,
    "sqlScale": 0
  }
```

The records generator previously applied the generic JSON Schema mapping and generated `float`,

  This change uses Oracle precision and scale metadata in the records profile:

  - Integral `NUMBER `values with precision up to 9 map to `int`.
  - Larger integral values map to `long`.
  - Nullable or optional values use `Integer` or `Long`.
  - Decimal values such as `NUMBER(7,2)` retain floating-point mapping.
  - Default JSON Schema generation remains unchanged.

  Adds regression coverage for duality-view-style schemas, including required and nullable identifiers and decimal values.